### PR TITLE
[CSP-1947] Fixing Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ utils.error.UserInputError('custom error message')
 
 A better usage alternative is to use destructuring, as in the example:
 ```
-const { UserInputError } = require('@trayio/connector-utils/lib/error')
+const { UserInputError } = require('@trayio/connector-utils/lib/errors')
 ```
 
 A full breakdown of available utilities is included in the documentation below.


### PR DESCRIPTION
Link to JIRA ticket: <https://trayio.atlassian.net/browse/CSP-1947>

Fixes Issue #9

```
const { UserInputError } = require('@trayio/connector-utils/lib/error')
```

Should be 
```
const { UserInputError } = require('@trayio/connector-utils/lib/errors')
```