### PR TITLE
[CSP-2198] Add npm version no tag

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+git-tag-version=false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@trayio/connector-utils",
-	"version": "0.2.1",
+	"version": "0.2.0",
 	"description": "Common utility functions used in connectors.",
 	"main": "lib/index.js",
 	"scripts": {


### PR DESCRIPTION
I didn't version properly and we want to be able to run npm version without tagging tings.