### PR TITLE
DDL -> handling of 0 as truthy in stead of falsey, if comes up as an …

### DIFF
--- a/lib/ddl.js
+++ b/lib/ddl.js
@@ -16,6 +16,7 @@ const validateArray = arr => {
 	}
 };
 const validateValue = (value, template, item) => {
+    if(parseInt(value, 10) === 0) return
 	if (!value) {
 		throw new ConnectorError(setErrorMessage(template), item);
 	}


### PR DESCRIPTION
If the ddl comes across an ID of zero, rightly so it recognises this as a falsey value and throws an error from validateValue. However in cases where the ID is zero, this is the wrong behaviour.

i.e. this data fed into ddl results in an error 
	data: [
		{
			id: 0,
			name: 'Interests',
			application_type: 'interests',
		},
	],

when it shouldn't?

I've edited my local version, thought i'd share if you want to include it :D its weird these id's start from zero, but this is based of a real example 