### PR TITLE
Missing link in readme 

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ It&#39;s important to note that this method will remove objects if they become e
 as a result of the nested key/value containing an empty object (the same goes
 for arrays).</p>
 </dd>
+<dt><a href="#removeAuthKeys">removeAuthKeys(collection, additionalKeys)</a></dt>
+<dd><p>Removes top levels '#' keys and additional top level keys if supplied.</p>
+</dd>
 <dt><a href="#validatePaginationRange">validatePaginationRange(value, validation)</a></dt>
 <dd><p>Helper for validating user pagination input for a given range.</p>
 </dd>


### PR DESCRIPTION
I noticed that there was no top level link to the removeAuthKeys function in the readme so I added it in.