### PR TITLE
[CSP-4743] add alias support to utils input schema generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,31 +400,38 @@ Helper for validating user pagination input for a given range.
 
 <a name="generateInputSchema"></a>
 
-## generateInputSchema({ schema, keys, operation = 'schema' })
+## generateInputSchema({ schema, keys, operation = 'schema', arrayMergeType = 'concatenate' })
 
 Helper for generating an operation input schema.
+
+**Kind**: global function
+
+| Param          | Type                | Description                                                                                                                                                            |
+| -------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| schema         | <code>Object</code> | The full connector schema definition.                                                                                                                                  |
+| keys           | <code>Object</code> | The keys that you wish to extract from the schema with any override values.                                                                                            |
+| operation      | <code>String</code> | The name of the connector operation that you are generating the schema for. This will be used as the root of the object path when logging validation issues. Optional. |
+| arrayMergeType | <code>String</code> | The type of merging algorithm to be used for arrays. Possible algorithms are `concatenate` (default), `combineByIndex`, `overwriteByIndex` or `overwrite`. Optional.   |
+| returns        | <code>Object</code> | A copy of the requested schema elements.                                                                                                                               |
+
+**Array merge types:**
+
+-   `concatenate` - merge arrays by concatenating values (default)
+-   `combineByIndex` - merge/combine arrays by index value
+    -   arrays of objects will merge by index (if possible)
+    -   other types will concatenate (ignoring value duplication overlap)
+-   `overwriteByIndex` - merge/overwrite arrays by index value
+    -   arrays of objects will merge by index (if possible)
+    -   other types will overwrite by index value
+-   `overwrite` - overwrite original array with specified array
 
 Will log to the console if:
 
 -   a requested key does not exist, or
--   `type` or `description` keys are missing
+-   `type` or `description` keys are missing, or
+-   a `description` does not end in a full stop
 
-Will not log to the console if requested key does not exist, but is overridden with at least a type and description.
-
--   @param {Object} schema The full connector schema definition.
--   @param {Object} keys The keys that you wish to extract from the schema with any override values.
--   @param {String} operation The name of the connector operation that you are generating the schema for.
--   This will be used as the root of the object path when logging validation issues.
--   @return {object} A copy of the requested schema elements.
-    \*/
-
-**Kind**: global function
-
-| Param     | Type                | Description                                                                 |
-| --------- | ------------------- | --------------------------------------------------------------------------- |
-| schema    | <code>Object</code> | The full connector schema definition.                                       |
-| keys      | <code>Object</code> | The keys that you wish to extract from the schema with any override values. |
-| operation | <code>String</code> | The name of the connector operation that you are generating the schema for. |
+Will not log to the console if requested key does not exist, but is overridden with at least a type and description with a full stop.
 
 For more information on how to use the schema generator, please see [schema-generation.md](./schema-generation.md).
 
@@ -439,6 +446,7 @@ generateInputSchema({
 		full_schema_key_2: {},
 		full_schema_key_3: {},
 	},
+	arrayMergeType: 'concatenate',
 });
 /**
  *	`fullSchema` is the complete schema definition for the connector
@@ -456,6 +464,7 @@ generateInputSchema({
 			required: true,
 			description: 'Override key values.',
 			default: 'value',
+			alias: 'key_2',
 		},
 		new_key: {
 			type: 'string',
@@ -468,7 +477,7 @@ generateInputSchema({
 /**
  *	`fullSchema` is the complete schema definition for the connector
  *	`full_schema_key_1` is extracted from the full schema without modification
- *	`full_schema_key_2` is extracted from the full schema and extended/overridden with extra keys and values
+ *	`full_schema_key_2` is extracted from the full schema and extended/overridden with extra keys and values. The key name will be changed to `key_2' by use of an alias.
  *	`new_key` is not in the full schema but it's full keys and values are supplied
  */
 ```

--- a/lib/deepMapKeys.js
+++ b/lib/deepMapKeys.js
@@ -19,7 +19,7 @@ const deepMapKeys = (collection, iteratee) => {
 		return _.transform(collection, (result, value, key) => {
 			return _.set(
 				result,
-				iteratee(key),
+				iteratee(key, value),
 				_.isObjectLike(value) ? deepMapKeys(value, iteratee) : value,
 			);
 		});

--- a/lib/generateInputSchema.js
+++ b/lib/generateInputSchema.js
@@ -5,16 +5,16 @@ const deepmerge = require('deepmerge');
 const deepMapKeys = require('./deepMapKeys');
 const logger = require('./internal/logger');
 
-const MISSING_KEYS_MESSAGE =
-	'There are missing schema keys that should be provided:';
+const INPUT_SCHEMA_PROBLEMS_MESSAGE =
+	'There are problems with the generated input schema:';
 
 const flattenAndCompact = ({ array }) => _.flattenDeep(_.compact(array));
 
 const logIssuesToConsole = ({ issues }) => {
 	if (issues.some(error => error.missing === 'type')) {
-		logger.log('error', MISSING_KEYS_MESSAGE);
+		logger.log('error', INPUT_SCHEMA_PROBLEMS_MESSAGE);
 	} else {
-		logger.log('warn', MISSING_KEYS_MESSAGE);
+		logger.log('warn', INPUT_SCHEMA_PROBLEMS_MESSAGE);
 	}
 	logger.log(
 		'table',
@@ -22,7 +22,7 @@ const logIssuesToConsole = ({ issues }) => {
 			key: error.key,
 			[error.missing]: 'missing',
 		})),
-		['key', 'type', 'description'],
+		['key', 'type', 'description', 'full stop'],
 	);
 };
 
@@ -96,6 +96,8 @@ const checkForIncompleteSchemaElements = ({ element, key }) => {
 		}
 		if (!keys.includes('description')) {
 			incompleteSchemaElements.push({ key, missing: 'description' });
+		} else if (!_.get(element, 'description', '.').endsWith('.')) {
+			incompleteSchemaElements.push({ key, missing: 'full stop' });
 		}
 	}
 	return incompleteSchemaElements;

--- a/lib/generateInputSchema.js
+++ b/lib/generateInputSchema.js
@@ -11,14 +11,14 @@ const INPUT_SCHEMA_PROBLEMS_MESSAGE =
 const flattenAndCompact = ({ array }) => _.flattenDeep(_.compact(array));
 
 const logIssuesToConsole = ({ issues }) => {
-	if (issues.some(error => error.missing === 'type')) {
+	if (issues.some((error) => error.missing === 'type')) {
 		logger.log('error', INPUT_SCHEMA_PROBLEMS_MESSAGE);
 	} else {
 		logger.log('warn', INPUT_SCHEMA_PROBLEMS_MESSAGE);
 	}
 	logger.log(
 		'table',
-		issues.map(error => ({
+		issues.map((error) => ({
 			key: error.key,
 			[error.missing]: 'missing',
 		})),
@@ -40,7 +40,7 @@ const shouldParseChildren = ({ key }) => !['lookup'].includes(key);
 const deepValidateSchema = ({ collection, iteratee, path = 'schema' }) => {
 	const recursiveArray = ({ col, fn, oPath }) => {
 		return Array.isArray(col)
-			? col.map(element =>
+			? col.map((element) =>
 					deepValidateSchema({
 						collection: element,
 						iteratee: fn,
@@ -103,8 +103,10 @@ const checkForIncompleteSchemaElements = ({ element, key }) => {
 	return incompleteSchemaElements;
 };
 
-const combine = (target, source, options, hard = false) => {
-	const soft = !hard;
+// target is the original array that you wish to merge into
+// source is the array that you wish to merge into the target array
+const combineByIndex = (target, source, options, overwrite = false) => {
+	const concatenate = !overwrite;
 	const destination = target.slice();
 
 	source.forEach((item, index) => {
@@ -115,9 +117,9 @@ const combine = (target, source, options, hard = false) => {
 			);
 		} else if (options.isMergeableObject(item)) {
 			destination[index] = deepmerge(target[index], item, options);
-		} else if (soft && target.indexOf(item) === -1) {
+		} else if (concatenate && target.indexOf(item) === -1) {
 			destination.push(item);
-		} else if (hard) {
+		} else if (overwrite) {
 			destination[index] = item;
 		}
 	});
@@ -126,10 +128,11 @@ const combine = (target, source, options, hard = false) => {
 };
 
 const arrayMergeFunctions = {
-	combine: (target, source, options) => combine(target, source, options),
+	mergeCombineByIndex: (target, source, options) =>
+		combineByIndex(target, source, options),
 
-	hardCombine: (target, source, options) =>
-		combine(target, source, options, true),
+	mergeOverwriteByIndex: (target, source, options) =>
+		combineByIndex(target, source, options, true),
 
 	overwrite: (target, source) => source,
 };
@@ -145,11 +148,11 @@ const arrayMergeFunctions = {
  * @param {String} operation The name of the connector operation that you are generating the schema for.
  *   This will be used as the root of the object path when logging validation issues.
  * @param {String} arrayMergeType The type of merging algorithm to be used for arrays.
- *   Possible algorithms are concatenate (default), combine, hardCombine or overwrite.
- *   'combine' - merge by index value (objects will merge if possible, other types will concatenate)
- *   'hardCombine' - merge by index value (objects will merge if possible, other types will overwrite)
- *   (default) - merge arrays by concatenating values (default)
- *   'overwrite' - replace first array with second
+ *   Possible algorithms are concatenate (default), mergeCombineByIndex, mergeOverwriteByIndex or overwrite.
+ *     concatenate - merge arrays by concatenating values (default)
+ *     mergeCombineByIndex - merge/combine arrays by index value (arrays of objects will merge by index if possible, other types will concatenate)
+ *     mergeOverwriteByIndex - merge/overwrite arrays by index value (arrays of objects will merge by index value if possible, other types will overwrite by index value)
+ *     overwrite - overwrite original array with specified array
  * @return {object} A copy of the requested schema elements.
  */
 const generateInputSchema = ({
@@ -163,16 +166,14 @@ const generateInputSchema = ({
 		},
 	},
 	operation = 'schema',
-	arrayMergeType = 'default',
+	arrayMergeType = 'concatenate',
 }) => {
 	// map the required input parameters to their individual schemas
 	// and override with any additionally provided values
 	const mappedSchema = _.map(keys, (value, key) => {
 		return {
 			[key]: deepmerge(schema[key], value, {
-				arrayMerge: arrayMergeFunctions[arrayMergeType]
-					? arrayMergeFunctions[arrayMergeType]
-					: arrayMergeFunctions.concatenate,
+				arrayMerge: arrayMergeFunctions[arrayMergeType],
 			}),
 		};
 	});

--- a/lib/generateInputSchema.js
+++ b/lib/generateInputSchema.js
@@ -1,5 +1,8 @@
 /* eslint-disable no-console */
 const _ = require('lodash');
+require('deepdash/addOmitDeep')(_);
+const deepmerge = require('deepmerge');
+const deepMapKeys = require('./deepMapKeys');
 const logger = require('./internal/logger');
 
 const MISSING_KEYS_MESSAGE =
@@ -114,13 +117,29 @@ const checkForIncompleteSchemaElements = ({ element, key }) => {
 const generateInputSchema = ({ schema, keys, operation = 'schema' }) => {
 	// map the required input parameters to their individual schemas
 	// and override with any additionally provided values
-	const mappedSchema = _.map(keys, (value, key) => ({
-		[key]: { ...schema[key], ...value },
-	}));
+	const mappedSchema = _.map(keys, (value, key) => {
+		return {
+			[key]: deepmerge(schema[key], value, {
+				arrayMerge: (destination, source) => [
+					...destination,
+					...source,
+				],
+			}),
+		};
+	});
+
+	// deep map change keys to aliases
+	const aliasedSchema = deepMapKeys(mappedSchema, (key, value) => {
+		const { alias } = value;
+		return alias || key;
+	});
+
+	// deep remove original alias keys
+	const transformedSchema = _.omitDeep(aliasedSchema, 'alias');
 
 	// find incomplete schema definitions
 	const incompleteSchemaErrors = deepValidateSchema({
-		collection: mappedSchema,
+		collection: transformedSchema,
 		iteratee: checkForIncompleteSchemaElements,
 		path: operation,
 	});
@@ -131,7 +150,7 @@ const generateInputSchema = ({ schema, keys, operation = 'schema' }) => {
 	}
 
 	// combine the individual schemas to a single operation schema
-	const combinedSchema = mappedSchema.reduce(
+	const combinedSchema = transformedSchema.reduce(
 		(acc, curr) => ({ ...acc, ...curr }),
 		{},
 	);

--- a/lib/generateInputSchema.js
+++ b/lib/generateInputSchema.js
@@ -128,10 +128,10 @@ const combineByIndex = (target, source, options, overwrite = false) => {
 };
 
 const arrayMergeFunctions = {
-	mergeCombineByIndex: (target, source, options) =>
+	combineByIndex: (target, source, options) =>
 		combineByIndex(target, source, options),
 
-	mergeOverwriteByIndex: (target, source, options) =>
+	overwriteByIndex: (target, source, options) =>
 		combineByIndex(target, source, options, true),
 
 	overwrite: (target, source) => source,
@@ -148,10 +148,10 @@ const arrayMergeFunctions = {
  * @param {String} operation The name of the connector operation that you are generating the schema for.
  *   This will be used as the root of the object path when logging validation issues.
  * @param {String} arrayMergeType The type of merging algorithm to be used for arrays.
- *   Possible algorithms are concatenate (default), mergeCombineByIndex, mergeOverwriteByIndex or overwrite.
+ *   Possible algorithms are concatenate (default), combineByIndex, overwriteByIndex or overwrite.
  *     concatenate - merge arrays by concatenating values (default)
- *     mergeCombineByIndex - merge/combine arrays by index value (arrays of objects will merge by index if possible, other types will concatenate)
- *     mergeOverwriteByIndex - merge/overwrite arrays by index value (arrays of objects will merge by index value if possible, other types will overwrite by index value)
+ *     combineByIndex - merge/combine arrays by index value (arrays of objects will merge by index if possible, other types will concatenate)
+ *     overwriteByIndex - merge/overwrite arrays by index value (arrays of objects will merge by index value if possible, other types will overwrite by index value)
  *     overwrite - overwrite original array with specified array
  * @return {object} A copy of the requested schema elements.
  */

--- a/lib/generateInputSchema.js
+++ b/lib/generateInputSchema.js
@@ -101,6 +101,30 @@ const checkForIncompleteSchemaElements = ({ element, key }) => {
 	return incompleteSchemaElements;
 };
 
+const arrayMergeFunctions = {
+	combine: (target, source, options) => {
+		const destination = target.slice();
+
+		source.forEach((item, index) => {
+			if (typeof destination[index] === 'undefined') {
+				destination[index] = options.cloneUnlessOtherwiseSpecified(
+					item,
+					options,
+				);
+			} else if (options.isMergeableObject(item)) {
+				destination[index] = deepmerge(target[index], item, options);
+			} else if (target.indexOf(item) === -1) {
+				destination.push(item);
+			}
+		});
+		return destination;
+	},
+
+	concatenate: (target, source) => [...target, ...source],
+
+	overwrite: (target, source) => source,
+};
+
 /**
  * Generates an operation input schema.
  * Will log to the console if a requested key does not exist.
@@ -111,19 +135,34 @@ const checkForIncompleteSchemaElements = ({ element, key }) => {
  * @param {Object} keys The keys that you wish to extract from the schema with any override values.
  * @param {String} operation The name of the connector operation that you are generating the schema for.
  *   This will be used as the root of the object path when logging validation issues.
+ * @param {String} arrayMergeType The type of merging algorithm to be used for arrays.
+ *   Possible values are concatenate (default), combine or overwrite.
+ *   'combine' - merge arrays of objects by index value
+ *   'concatenate' - merge arrays by appending new values (default)
+ *   'overwrite' - replace first array with second
  * @return {object} A copy of the requested schema elements.
  */
-
-const generateInputSchema = ({ schema, keys, operation = 'schema' }) => {
+const generateInputSchema = ({
+	schema = {},
+	keys = {
+		key_name: {
+			type: 'string',
+			description: 'Description.',
+			title: '',
+			default: '',
+		},
+	},
+	operation = 'schema',
+	arrayMergeType = 'concatenate',
+}) => {
 	// map the required input parameters to their individual schemas
 	// and override with any additionally provided values
 	const mappedSchema = _.map(keys, (value, key) => {
 		return {
 			[key]: deepmerge(schema[key], value, {
-				arrayMerge: (destination, source) => [
-					...destination,
-					...source,
-				],
+				arrayMerge: arrayMergeFunctions[arrayMergeType]
+					? arrayMergeFunctions[arrayMergeType]
+					: arrayMergeFunctions.concatenate,
 			}),
 		};
 	});

--- a/lib/generateInputSchema.js
+++ b/lib/generateInputSchema.js
@@ -103,26 +103,33 @@ const checkForIncompleteSchemaElements = ({ element, key }) => {
 	return incompleteSchemaElements;
 };
 
+const combine = (target, source, options, hard = false) => {
+	const soft = !hard;
+	const destination = target.slice();
+
+	source.forEach((item, index) => {
+		if (typeof destination[index] === 'undefined') {
+			destination[index] = options.cloneUnlessOtherwiseSpecified(
+				item,
+				options,
+			);
+		} else if (options.isMergeableObject(item)) {
+			destination[index] = deepmerge(target[index], item, options);
+		} else if (soft && target.indexOf(item) === -1) {
+			destination.push(item);
+		} else if (hard) {
+			destination[index] = item;
+		}
+	});
+
+	return destination;
+};
+
 const arrayMergeFunctions = {
-	combine: (target, source, options) => {
-		const destination = target.slice();
+	combine: (target, source, options) => combine(target, source, options),
 
-		source.forEach((item, index) => {
-			if (typeof destination[index] === 'undefined') {
-				destination[index] = options.cloneUnlessOtherwiseSpecified(
-					item,
-					options,
-				);
-			} else if (options.isMergeableObject(item)) {
-				destination[index] = deepmerge(target[index], item, options);
-			} else if (target.indexOf(item) === -1) {
-				destination.push(item);
-			}
-		});
-		return destination;
-	},
-
-	concatenate: (target, source) => [...target, ...source],
+	hardCombine: (target, source, options) =>
+		combine(target, source, options, true),
 
 	overwrite: (target, source) => source,
 };
@@ -138,9 +145,10 @@ const arrayMergeFunctions = {
  * @param {String} operation The name of the connector operation that you are generating the schema for.
  *   This will be used as the root of the object path when logging validation issues.
  * @param {String} arrayMergeType The type of merging algorithm to be used for arrays.
- *   Possible values are concatenate (default), combine or overwrite.
- *   'combine' - merge arrays of objects by index value
- *   'concatenate' - merge arrays by appending new values (default)
+ *   Possible algorithms are concatenate (default), combine, hardCombine or overwrite.
+ *   'combine' - merge by index value (objects will merge if possible, other types will concatenate)
+ *   'hardCombine' - merge by index value (objects will merge if possible, other types will overwrite)
+ *   (default) - merge arrays by concatenating values (default)
  *   'overwrite' - replace first array with second
  * @return {object} A copy of the requested schema elements.
  */
@@ -155,7 +163,7 @@ const generateInputSchema = ({
 		},
 	},
 	operation = 'schema',
-	arrayMergeType = 'concatenate',
+	arrayMergeType = 'default',
 }) => {
 	// map the required input parameters to their individual schemas
 	// and override with any additionally provided values

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,56 +5,45 @@
 	"requires": true,
 	"dependencies": {
 		"@babel/code-frame": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-			"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+			"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
 			"dev": true,
 			"requires": {
-				"@babel/highlight": "^7.0.0"
+				"@babel/highlight": "^7.10.4"
 			}
 		},
 		"@babel/core": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
-			"integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
+			"version": "7.11.6",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.6.tgz",
+			"integrity": "sha512-Wpcv03AGnmkgm6uS6k8iwhIwTrcP0m17TL1n1sy7qD0qelDu4XNeW0dN0mHfa+Gei211yDaLoEe/VlbXQzM4Bg==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.8.3",
-				"@babel/generator": "^7.9.0",
-				"@babel/helper-module-transforms": "^7.9.0",
-				"@babel/helpers": "^7.9.0",
-				"@babel/parser": "^7.9.0",
-				"@babel/template": "^7.8.6",
-				"@babel/traverse": "^7.9.0",
-				"@babel/types": "^7.9.0",
+				"@babel/code-frame": "^7.10.4",
+				"@babel/generator": "^7.11.6",
+				"@babel/helper-module-transforms": "^7.11.0",
+				"@babel/helpers": "^7.10.4",
+				"@babel/parser": "^7.11.5",
+				"@babel/template": "^7.10.4",
+				"@babel/traverse": "^7.11.5",
+				"@babel/types": "^7.11.5",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.1",
 				"json5": "^2.1.2",
-				"lodash": "^4.17.13",
+				"lodash": "^4.17.19",
 				"resolve": "^1.3.2",
 				"semver": "^5.4.1",
 				"source-map": "^0.5.0"
 			},
 			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-					"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+				"json5": {
+					"version": "2.1.3",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+					"integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
 					"dev": true,
 					"requires": {
-						"@babel/highlight": "^7.8.3"
-					}
-				},
-				"@babel/highlight": {
-					"version": "7.9.0",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
-					"integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-validator-identifier": "^7.9.0",
-						"chalk": "^2.0.0",
-						"js-tokens": "^4.0.0"
+						"minimist": "^1.2.5"
 					}
 				},
 				"semver": {
@@ -72,14 +61,13 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.9.4",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.4.tgz",
-			"integrity": "sha512-rjP8ahaDy/ouhrvCoU1E5mqaitWrxwuNGU+dy1EpaoK48jZay4MdkskKGIMHLZNewg8sAsqpGSREJwP0zH3YQA==",
+			"version": "7.11.6",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
+			"integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.9.0",
+				"@babel/types": "^7.11.5",
 				"jsesc": "^2.5.1",
-				"lodash": "^4.17.13",
 				"source-map": "^0.5.0"
 			},
 			"dependencies": {
@@ -92,137 +80,146 @@
 			}
 		},
 		"@babel/helper-function-name": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
-			"integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+			"integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-get-function-arity": "^7.8.3",
-				"@babel/template": "^7.8.3",
-				"@babel/types": "^7.8.3"
+				"@babel/helper-get-function-arity": "^7.10.4",
+				"@babel/template": "^7.10.4",
+				"@babel/types": "^7.10.4"
 			}
 		},
 		"@babel/helper-get-function-arity": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
-			"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+			"integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.8.3"
+				"@babel/types": "^7.10.4"
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz",
-			"integrity": "sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==",
+			"version": "7.11.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
+			"integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.8.3"
+				"@babel/types": "^7.11.0"
 			}
 		},
 		"@babel/helper-module-imports": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz",
-			"integrity": "sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
+			"integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.8.3"
+				"@babel/types": "^7.10.4"
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz",
-			"integrity": "sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==",
+			"version": "7.11.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz",
+			"integrity": "sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "^7.8.3",
-				"@babel/helper-replace-supers": "^7.8.6",
-				"@babel/helper-simple-access": "^7.8.3",
-				"@babel/helper-split-export-declaration": "^7.8.3",
-				"@babel/template": "^7.8.6",
-				"@babel/types": "^7.9.0",
-				"lodash": "^4.17.13"
+				"@babel/helper-module-imports": "^7.10.4",
+				"@babel/helper-replace-supers": "^7.10.4",
+				"@babel/helper-simple-access": "^7.10.4",
+				"@babel/helper-split-export-declaration": "^7.11.0",
+				"@babel/template": "^7.10.4",
+				"@babel/types": "^7.11.0",
+				"lodash": "^4.17.19"
 			}
 		},
 		"@babel/helper-optimise-call-expression": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz",
-			"integrity": "sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
+			"integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.8.3"
+				"@babel/types": "^7.10.4"
 			}
 		},
 		"@babel/helper-plugin-utils": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-			"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+			"integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
 			"dev": true
 		},
 		"@babel/helper-replace-supers": {
-			"version": "7.8.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.6.tgz",
-			"integrity": "sha512-PeMArdA4Sv/Wf4zXwBKPqVj7n9UF/xg6slNRtZW84FM7JpE1CbG8B612FyM4cxrf4fMAMGO0kR7voy1ForHHFA==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
+			"integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-member-expression-to-functions": "^7.8.3",
-				"@babel/helper-optimise-call-expression": "^7.8.3",
-				"@babel/traverse": "^7.8.6",
-				"@babel/types": "^7.8.6"
+				"@babel/helper-member-expression-to-functions": "^7.10.4",
+				"@babel/helper-optimise-call-expression": "^7.10.4",
+				"@babel/traverse": "^7.10.4",
+				"@babel/types": "^7.10.4"
 			}
 		},
 		"@babel/helper-simple-access": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz",
-			"integrity": "sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
+			"integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.8.3",
-				"@babel/types": "^7.8.3"
+				"@babel/template": "^7.10.4",
+				"@babel/types": "^7.10.4"
 			}
 		},
 		"@babel/helper-split-export-declaration": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
-			"integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+			"version": "7.11.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+			"integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.8.3"
+				"@babel/types": "^7.11.0"
 			}
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.0.tgz",
-			"integrity": "sha512-6G8bQKjOh+of4PV/ThDm/rRqlU7+IGoJuofpagU5GlEl29Vv0RGqqt86ZGRV8ZuSOY3o+8yXl5y782SMcG7SHw==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+			"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
 			"dev": true
 		},
 		"@babel/helpers": {
-			"version": "7.9.2",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.9.2.tgz",
-			"integrity": "sha512-JwLvzlXVPjO8eU9c/wF9/zOIN7X6h8DYf7mG4CiFRZRvZNKEF5dQ3H3V+ASkHoIB3mWhatgl5ONhyqHRI6MppA==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.4.tgz",
+			"integrity": "sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.8.3",
-				"@babel/traverse": "^7.9.0",
-				"@babel/types": "^7.9.0"
+				"@babel/template": "^7.10.4",
+				"@babel/traverse": "^7.10.4",
+				"@babel/types": "^7.10.4"
 			}
 		},
 		"@babel/highlight": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
-			"integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+			"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
 			"dev": true,
 			"requires": {
+				"@babel/helper-validator-identifier": "^7.10.4",
 				"chalk": "^2.0.0",
-				"esutils": "^2.0.2",
 				"js-tokens": "^4.0.0"
 			}
 		},
 		"@babel/parser": {
-			"version": "7.9.4",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
-			"integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA==",
+			"version": "7.11.5",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
+			"integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==",
 			"dev": true
+		},
+		"@babel/plugin-syntax-async-generators": {
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+			"integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
 		},
 		"@babel/plugin-syntax-bigint": {
 			"version": "7.8.3",
@@ -231,6 +228,60 @@
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-class-properties": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.10.4.tgz",
+			"integrity": "sha512-GCSBF7iUle6rNugfURwNmCGG3Z/2+opxAMLs1nND4bhEG5PuxTIggDBoeYYSujAlLtsupzOHYJQgPS3pivwXIA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-syntax-import-meta": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+			"integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-syntax-json-strings": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+			"integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-logical-assignment-operators": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+			"integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-syntax-nullish-coalescing-operator": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+			"integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-numeric-separator": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+			"integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-syntax-object-rest-spread": {
@@ -242,95 +293,87 @@
 				"@babel/helper-plugin-utils": "^7.8.0"
 			}
 		},
-		"@babel/runtime": {
-			"version": "7.8.4",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.4.tgz",
-			"integrity": "sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==",
+		"@babel/plugin-syntax-optional-catch-binding": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+			"integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
 			"dev": true,
 			"requires": {
-				"regenerator-runtime": "^0.13.2"
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-optional-chaining": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+			"integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/runtime": {
+			"version": "7.11.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+			"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+			"dev": true,
+			"requires": {
+				"regenerator-runtime": "^0.13.4"
+			}
+		},
+		"@babel/runtime-corejs3": {
+			"version": "7.11.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.11.2.tgz",
+			"integrity": "sha512-qh5IR+8VgFz83VBa6OkaET6uN/mJOhHONuy3m1sgF0CV6mXdPSEBdA7e1eUbVvyNtANjMbg22JUv71BaDXLY6A==",
+			"dev": true,
+			"requires": {
+				"core-js-pure": "^3.0.0",
+				"regenerator-runtime": "^0.13.4"
 			}
 		},
 		"@babel/template": {
-			"version": "7.8.6",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
-			"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+			"integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.8.3",
-				"@babel/parser": "^7.8.6",
-				"@babel/types": "^7.8.6"
-			},
-			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-					"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-					"dev": true,
-					"requires": {
-						"@babel/highlight": "^7.8.3"
-					}
-				},
-				"@babel/highlight": {
-					"version": "7.9.0",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
-					"integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-validator-identifier": "^7.9.0",
-						"chalk": "^2.0.0",
-						"js-tokens": "^4.0.0"
-					}
-				}
+				"@babel/code-frame": "^7.10.4",
+				"@babel/parser": "^7.10.4",
+				"@babel/types": "^7.10.4"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.0.tgz",
-			"integrity": "sha512-jAZQj0+kn4WTHO5dUZkZKhbFrqZE7K5LAQ5JysMnmvGij+wOdr+8lWqPeW0BcF4wFwrEXXtdGO7wcV6YPJcf3w==",
+			"version": "7.11.5",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
+			"integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.8.3",
-				"@babel/generator": "^7.9.0",
-				"@babel/helper-function-name": "^7.8.3",
-				"@babel/helper-split-export-declaration": "^7.8.3",
-				"@babel/parser": "^7.9.0",
-				"@babel/types": "^7.9.0",
+				"@babel/code-frame": "^7.10.4",
+				"@babel/generator": "^7.11.5",
+				"@babel/helper-function-name": "^7.10.4",
+				"@babel/helper-split-export-declaration": "^7.11.0",
+				"@babel/parser": "^7.11.5",
+				"@babel/types": "^7.11.5",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0",
-				"lodash": "^4.17.13"
+				"lodash": "^4.17.19"
 			},
 			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-					"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-					"dev": true,
-					"requires": {
-						"@babel/highlight": "^7.8.3"
-					}
-				},
-				"@babel/highlight": {
-					"version": "7.9.0",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
-					"integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-validator-identifier": "^7.9.0",
-						"chalk": "^2.0.0",
-						"js-tokens": "^4.0.0"
-					}
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
 				}
 			}
 		},
 		"@babel/types": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
-			"integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
+			"version": "7.11.5",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
+			"integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.9.0",
-				"lodash": "^4.17.13",
+				"@babel/helper-validator-identifier": "^7.10.4",
+				"lodash": "^4.17.19",
 				"to-fast-properties": "^2.0.0"
 			}
 		},
@@ -348,28 +391,108 @@
 			"requires": {
 				"exec-sh": "^0.3.2",
 				"minimist": "^1.2.0"
+			}
+		},
+		"@eslint/eslintrc": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.1.3.tgz",
+			"integrity": "sha512-4YVwPkANLeNtRjMekzux1ci8hIaH5eGKktGqR0d3LWsKNn5B2X/1Z6Trxy7jQXl9EBGE6Yj02O+t09FMeRllaA==",
+			"dev": true,
+			"requires": {
+				"ajv": "^6.12.4",
+				"debug": "^4.1.1",
+				"espree": "^7.3.0",
+				"globals": "^12.1.0",
+				"ignore": "^4.0.6",
+				"import-fresh": "^3.2.1",
+				"js-yaml": "^3.13.1",
+				"lodash": "^4.17.19",
+				"minimatch": "^3.0.4",
+				"strip-json-comments": "^3.1.1"
 			},
 			"dependencies": {
-				"minimist": {
-					"version": "1.2.5",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+				"ajv": {
+					"version": "6.12.5",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
+					"integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "^3.1.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
+					}
+				},
+				"fast-deep-equal": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+					"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
 					"dev": true
 				}
 			}
 		},
 		"@istanbuljs/load-nyc-config": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
-			"integrity": "sha512-ZR0rq/f/E4f4XcgnDvtMWXCUJpi8eO0rssVhmztsZqLIEFA9UUP9zmpE0VxlM+kv/E1ul2I876Fwil2ayptDVg==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+			"integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
 			"dev": true,
 			"requires": {
 				"camelcase": "^5.3.1",
 				"find-up": "^4.1.0",
+				"get-package-type": "^0.1.0",
 				"js-yaml": "^3.13.1",
 				"resolve-from": "^5.0.0"
 			},
 			"dependencies": {
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				},
 				"resolve-from": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -385,17 +508,50 @@
 			"dev": true
 		},
 		"@jest/console": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/@jest/console/-/console-25.2.1.tgz",
-			"integrity": "sha512-v3tkMr5AeVm6R23wnZdC5dzXdHPFa6j2uiTC15iHISYkGIilE9O1qmAYKELHPXZifDbz9c8WwzsqoN8K8uG4jg==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-26.3.0.tgz",
+			"integrity": "sha512-/5Pn6sJev0nPUcAdpJHMVIsA8sKizL2ZkcKPE5+dJrCccks7tcM7c9wbgHudBJbxXLoTbqsHkG1Dofoem4F09w==",
 			"dev": true,
 			"requires": {
-				"@jest/source-map": "^25.2.1",
-				"chalk": "^3.0.0",
-				"jest-util": "^25.2.1",
+				"@jest/types": "^26.3.0",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"jest-message-util": "^26.3.0",
+				"jest-util": "^26.3.0",
 				"slash": "^3.0.0"
 			},
 			"dependencies": {
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"@types/yargs": {
+					"version": "15.0.7",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
+					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
+					"dev": true,
+					"requires": {
+						"@types/yargs-parser": "*"
+					}
+				},
 				"ansi-styles": {
 					"version": "4.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
@@ -407,9 +563,9 @@
 					}
 				},
 				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
@@ -438,9 +594,9 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -449,57 +605,67 @@
 			}
 		},
 		"@jest/core": {
-			"version": "25.2.2",
-			"resolved": "https://registry.npmjs.org/@jest/core/-/core-25.2.2.tgz",
-			"integrity": "sha512-dSPhksPMRvuE5WLQODFqaiuubBe1r92XAl3m47m8rC2uf6PqxxkeiI1meGAPLT1j1SevdqklECpy+mkMGrDO9w==",
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-26.4.2.tgz",
+			"integrity": "sha512-sDva7YkeNprxJfepOctzS8cAk9TOekldh+5FhVuXS40+94SHbiicRO1VV2tSoRtgIo+POs/Cdyf8p76vPTd6dg==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^25.2.1",
-				"@jest/reporters": "^25.2.1",
-				"@jest/test-result": "^25.2.1",
-				"@jest/transform": "^25.2.1",
-				"@jest/types": "^25.2.1",
+				"@jest/console": "^26.3.0",
+				"@jest/reporters": "^26.4.1",
+				"@jest/test-result": "^26.3.0",
+				"@jest/transform": "^26.3.0",
+				"@jest/types": "^26.3.0",
+				"@types/node": "*",
 				"ansi-escapes": "^4.2.1",
-				"chalk": "^3.0.0",
+				"chalk": "^4.0.0",
 				"exit": "^0.1.2",
-				"graceful-fs": "^4.2.3",
-				"jest-changed-files": "^25.2.1",
-				"jest-config": "^25.2.2",
-				"jest-haste-map": "^25.2.1",
-				"jest-message-util": "^25.2.1",
-				"jest-regex-util": "^25.2.1",
-				"jest-resolve": "^25.2.1",
-				"jest-resolve-dependencies": "^25.2.2",
-				"jest-runner": "^25.2.2",
-				"jest-runtime": "^25.2.2",
-				"jest-snapshot": "^25.2.1",
-				"jest-util": "^25.2.1",
-				"jest-validate": "^25.2.1",
-				"jest-watcher": "^25.2.1",
+				"graceful-fs": "^4.2.4",
+				"jest-changed-files": "^26.3.0",
+				"jest-config": "^26.4.2",
+				"jest-haste-map": "^26.3.0",
+				"jest-message-util": "^26.3.0",
+				"jest-regex-util": "^26.0.0",
+				"jest-resolve": "^26.4.0",
+				"jest-resolve-dependencies": "^26.4.2",
+				"jest-runner": "^26.4.2",
+				"jest-runtime": "^26.4.2",
+				"jest-snapshot": "^26.4.2",
+				"jest-util": "^26.3.0",
+				"jest-validate": "^26.4.2",
+				"jest-watcher": "^26.3.0",
 				"micromatch": "^4.0.2",
 				"p-each-series": "^2.1.0",
-				"realpath-native": "^2.0.0",
 				"rimraf": "^3.0.0",
 				"slash": "^3.0.0",
 				"strip-ansi": "^6.0.0"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-25.2.1.tgz",
-					"integrity": "sha512-WuGFGJ3Rrycg+5ZwQTWKjr21M9psANPAWYD28K42hSeUzhv1H591VXIoq0tjs00mydhNOgVOkKSpzRS3CrOYFw==",
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^1.1.1",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
 						"@types/yargs": "^15.0.0",
-						"chalk": "^3.0.0"
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.4",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-					"integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+					"version": "15.0.7",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
+					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -516,9 +682,9 @@
 					}
 				},
 				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
@@ -538,12 +704,6 @@
 					"version": "1.1.4",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"graceful-fs": {
-					"version": "4.2.3",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-					"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
 					"dev": true
 				},
 				"has-flag": {
@@ -561,19 +721,10 @@
 						"glob": "^7.1.3"
 					}
 				},
-				"strip-ansi": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^5.0.0"
-					}
-				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -582,32 +733,43 @@
 			}
 		},
 		"@jest/environment": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-25.2.1.tgz",
-			"integrity": "sha512-aeA3UlUmpblmv2CHBcNA7LvcXlcCtRpXaKKFVooRy9/Jk8B4IZAZMfrML/d+1cG5FpF17s4JVdu1kx0mbnaqTQ==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.3.0.tgz",
+			"integrity": "sha512-EW+MFEo0DGHahf83RAaiqQx688qpXgl99wdb8Fy67ybyzHwR1a58LHcO376xQJHfmoXTu89M09dH3J509cx2AA==",
 			"dev": true,
 			"requires": {
-				"@jest/fake-timers": "^25.2.1",
-				"@jest/types": "^25.2.1",
-				"jest-mock": "^25.2.1"
+				"@jest/fake-timers": "^26.3.0",
+				"@jest/types": "^26.3.0",
+				"@types/node": "*",
+				"jest-mock": "^26.3.0"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-25.2.1.tgz",
-					"integrity": "sha512-WuGFGJ3Rrycg+5ZwQTWKjr21M9psANPAWYD28K42hSeUzhv1H591VXIoq0tjs00mydhNOgVOkKSpzRS3CrOYFw==",
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^1.1.1",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
 						"@types/yargs": "^15.0.0",
-						"chalk": "^3.0.0"
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.4",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-					"integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+					"version": "15.0.7",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
+					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -624,9 +786,9 @@
 					}
 				},
 				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
@@ -655,9 +817,9 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -666,34 +828,45 @@
 			}
 		},
 		"@jest/fake-timers": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-25.2.1.tgz",
-			"integrity": "sha512-H1OC8AktrGTD10NHBauICkRCv7VOOrsgI8xokifAsxJMYhqoKBtJZbk2YpbrtnmdTUnk+qoxPUk+Mufwnl44iQ==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.3.0.tgz",
+			"integrity": "sha512-ZL9ytUiRwVP8ujfRepffokBvD2KbxbqMhrXSBhSdAhISCw3gOkuntisiSFv+A6HN0n0fF4cxzICEKZENLmW+1A==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^25.2.1",
-				"jest-message-util": "^25.2.1",
-				"jest-mock": "^25.2.1",
-				"jest-util": "^25.2.1",
-				"lolex": "^5.0.0"
+				"@jest/types": "^26.3.0",
+				"@sinonjs/fake-timers": "^6.0.1",
+				"@types/node": "*",
+				"jest-message-util": "^26.3.0",
+				"jest-mock": "^26.3.0",
+				"jest-util": "^26.3.0"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-25.2.1.tgz",
-					"integrity": "sha512-WuGFGJ3Rrycg+5ZwQTWKjr21M9psANPAWYD28K42hSeUzhv1H591VXIoq0tjs00mydhNOgVOkKSpzRS3CrOYFw==",
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^1.1.1",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
 						"@types/yargs": "^15.0.0",
-						"chalk": "^3.0.0"
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.4",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-					"integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+					"version": "15.0.7",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
+					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -710,9 +883,9 @@
 					}
 				},
 				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
@@ -741,9 +914,103 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
+		"@jest/globals": {
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.4.2.tgz",
+			"integrity": "sha512-Ot5ouAlehhHLRhc+sDz2/9bmNv9p5ZWZ9LE1pXGGTCXBasmi5jnYjlgYcYt03FBwLmZXCZ7GrL29c33/XRQiow==",
+			"dev": true,
+			"requires": {
+				"@jest/environment": "^26.3.0",
+				"@jest/types": "^26.3.0",
+				"expect": "^26.4.2"
+			},
+			"dependencies": {
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"@types/yargs": {
+					"version": "15.0.7",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
+					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
+					"dev": true,
+					"requires": {
+						"@types/yargs-parser": "*"
+					}
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -752,53 +1019,64 @@
 			}
 		},
 		"@jest/reporters": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-25.2.1.tgz",
-			"integrity": "sha512-jAnIECIIFVHiASKLpPBpZ9fIgWolKdMwUuyjSlNVixmtX6G83fyiGaOquaAU1ukAxnlKdCLjvH6BYdY+GGbd5Q==",
+			"version": "26.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.4.1.tgz",
+			"integrity": "sha512-aROTkCLU8++yiRGVxLsuDmZsQEKO6LprlrxtAuzvtpbIFl3eIjgIf3EUxDKgomkS25R9ZzwGEdB5weCcBZlrpQ==",
 			"dev": true,
 			"requires": {
 				"@bcoe/v8-coverage": "^0.2.3",
-				"@jest/console": "^25.2.1",
-				"@jest/test-result": "^25.2.1",
-				"@jest/transform": "^25.2.1",
-				"@jest/types": "^25.2.1",
-				"chalk": "^3.0.0",
+				"@jest/console": "^26.3.0",
+				"@jest/test-result": "^26.3.0",
+				"@jest/transform": "^26.3.0",
+				"@jest/types": "^26.3.0",
+				"chalk": "^4.0.0",
 				"collect-v8-coverage": "^1.0.0",
 				"exit": "^0.1.2",
 				"glob": "^7.1.2",
+				"graceful-fs": "^4.2.4",
 				"istanbul-lib-coverage": "^3.0.0",
-				"istanbul-lib-instrument": "^4.0.0",
+				"istanbul-lib-instrument": "^4.0.3",
 				"istanbul-lib-report": "^3.0.0",
 				"istanbul-lib-source-maps": "^4.0.0",
-				"istanbul-reports": "^3.0.0",
-				"jest-haste-map": "^25.2.1",
-				"jest-resolve": "^25.2.1",
-				"jest-util": "^25.2.1",
-				"jest-worker": "^25.2.1",
-				"node-notifier": "^6.0.0",
+				"istanbul-reports": "^3.0.2",
+				"jest-haste-map": "^26.3.0",
+				"jest-resolve": "^26.4.0",
+				"jest-util": "^26.3.0",
+				"jest-worker": "^26.3.0",
+				"node-notifier": "^8.0.0",
 				"slash": "^3.0.0",
 				"source-map": "^0.6.0",
-				"string-length": "^3.1.0",
+				"string-length": "^4.0.1",
 				"terminal-link": "^2.0.0",
-				"v8-to-istanbul": "^4.0.1"
+				"v8-to-istanbul": "^5.0.1"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-25.2.1.tgz",
-					"integrity": "sha512-WuGFGJ3Rrycg+5ZwQTWKjr21M9psANPAWYD28K42hSeUzhv1H591VXIoq0tjs00mydhNOgVOkKSpzRS3CrOYFw==",
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^1.1.1",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
 						"@types/yargs": "^15.0.0",
-						"chalk": "^3.0.0"
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.4",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-					"integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+					"version": "15.0.7",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
+					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -815,9 +1093,9 @@
 					}
 				},
 				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
@@ -846,9 +1124,9 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -857,53 +1135,54 @@
 			}
 		},
 		"@jest/source-map": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-25.2.1.tgz",
-			"integrity": "sha512-PgScGJm1U27+9Te/cxP4oUFqJ2PX6NhBL2a6unQ7yafCgs8k02c0LSyjSIx/ao0AwcAdCczfAPDf5lJ7zoB/7A==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.3.0.tgz",
+			"integrity": "sha512-hWX5IHmMDWe1kyrKl7IhFwqOuAreIwHhbe44+XH2ZRHjrKIh0LO5eLQ/vxHFeAfRwJapmxuqlGAEYLadDq6ZGQ==",
 			"dev": true,
 			"requires": {
 				"callsites": "^3.0.0",
-				"graceful-fs": "^4.2.3",
+				"graceful-fs": "^4.2.4",
 				"source-map": "^0.6.0"
-			},
-			"dependencies": {
-				"graceful-fs": {
-					"version": "4.2.3",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-					"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
-					"dev": true
-				}
 			}
 		},
 		"@jest/test-result": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-25.2.1.tgz",
-			"integrity": "sha512-E0tlWh2iOELRLbbPEngs3Dsx88vGBQOs6O3w46YeXfMHlwwqzWrlvoeUq6kRlHRm1O8H+EBr60Wtrwh20C+zWQ==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.3.0.tgz",
+			"integrity": "sha512-a8rbLqzW/q7HWheFVMtghXV79Xk+GWwOK1FrtimpI5n1la2SY0qHri3/b0/1F0Ve0/yJmV8pEhxDfVwiUBGtgg==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^25.2.1",
-				"@jest/transform": "^25.2.1",
-				"@jest/types": "^25.2.1",
+				"@jest/console": "^26.3.0",
+				"@jest/types": "^26.3.0",
 				"@types/istanbul-lib-coverage": "^2.0.0",
 				"collect-v8-coverage": "^1.0.0"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-25.2.1.tgz",
-					"integrity": "sha512-WuGFGJ3Rrycg+5ZwQTWKjr21M9psANPAWYD28K42hSeUzhv1H591VXIoq0tjs00mydhNOgVOkKSpzRS3CrOYFw==",
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^1.1.1",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
 						"@types/yargs": "^15.0.0",
-						"chalk": "^3.0.0"
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.4",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-					"integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+					"version": "15.0.7",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
+					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -920,9 +1199,9 @@
 					}
 				},
 				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
@@ -951,9 +1230,9 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -962,57 +1241,67 @@
 			}
 		},
 		"@jest/test-sequencer": {
-			"version": "25.2.2",
-			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-25.2.2.tgz",
-			"integrity": "sha512-bN1LH30EygCNrZS7gkKBmqBxQwilYiMlAV+wY9oWFRY4VZAxvPwqg5/f0DrZQc60vTW1fXWrkfslSa87sO/P5A==",
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.4.2.tgz",
+			"integrity": "sha512-83DRD8N3M0tOhz9h0bn6Kl6dSp+US6DazuVF8J9m21WAp5x7CqSMaNycMP0aemC/SH/pDQQddbsfHRTBXVUgog==",
 			"dev": true,
 			"requires": {
-				"@jest/test-result": "^25.2.1",
-				"jest-haste-map": "^25.2.1",
-				"jest-runner": "^25.2.2",
-				"jest-runtime": "^25.2.2"
+				"@jest/test-result": "^26.3.0",
+				"graceful-fs": "^4.2.4",
+				"jest-haste-map": "^26.3.0",
+				"jest-runner": "^26.4.2",
+				"jest-runtime": "^26.4.2"
 			}
 		},
 		"@jest/transform": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-25.2.1.tgz",
-			"integrity": "sha512-puoD5EfqPeZ5m0dV9l8+PMdOVdRjeWcaEjGkH+eG45l0nPJ2vRcxu8J6CRl/6nQ5ZTHgg7LuM9C6FauNpdRpUA==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.3.0.tgz",
+			"integrity": "sha512-Isj6NB68QorGoFWvcOjlUhpkT56PqNIsXKR7XfvoDlCANn/IANlh8DrKAA2l2JKC3yWSMH5wS0GwuQM20w3b2A==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.1.0",
-				"@jest/types": "^25.2.1",
+				"@jest/types": "^26.3.0",
 				"babel-plugin-istanbul": "^6.0.0",
-				"chalk": "^3.0.0",
+				"chalk": "^4.0.0",
 				"convert-source-map": "^1.4.0",
 				"fast-json-stable-stringify": "^2.0.0",
-				"graceful-fs": "^4.2.3",
-				"jest-haste-map": "^25.2.1",
-				"jest-regex-util": "^25.2.1",
-				"jest-util": "^25.2.1",
+				"graceful-fs": "^4.2.4",
+				"jest-haste-map": "^26.3.0",
+				"jest-regex-util": "^26.0.0",
+				"jest-util": "^26.3.0",
 				"micromatch": "^4.0.2",
 				"pirates": "^4.0.1",
-				"realpath-native": "^2.0.0",
 				"slash": "^3.0.0",
 				"source-map": "^0.6.1",
 				"write-file-atomic": "^3.0.0"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-25.2.1.tgz",
-					"integrity": "sha512-WuGFGJ3Rrycg+5ZwQTWKjr21M9psANPAWYD28K42hSeUzhv1H591VXIoq0tjs00mydhNOgVOkKSpzRS3CrOYFw==",
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^1.1.1",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
 						"@types/yargs": "^15.0.0",
-						"chalk": "^3.0.0"
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.4",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-					"integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+					"version": "15.0.7",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
+					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -1029,9 +1318,9 @@
 					}
 				},
 				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
@@ -1053,12 +1342,6 @@
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 					"dev": true
 				},
-				"graceful-fs": {
-					"version": "4.2.3",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-					"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
-					"dev": true
-				},
 				"has-flag": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -1066,9 +1349,9 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -1087,19 +1370,54 @@
 				"@types/yargs": "^13.0.0"
 			}
 		},
+		"@nodelib/fs.scandir": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+			"integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+			"dev": true,
+			"requires": {
+				"@nodelib/fs.stat": "2.0.3",
+				"run-parallel": "^1.1.9"
+			}
+		},
+		"@nodelib/fs.stat": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+			"integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+			"dev": true
+		},
+		"@nodelib/fs.walk": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+			"integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+			"dev": true,
+			"requires": {
+				"@nodelib/fs.scandir": "2.1.3",
+				"fastq": "^1.6.0"
+			}
+		},
 		"@sinonjs/commons": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.1.tgz",
-			"integrity": "sha512-Debi3Baff1Qu1Unc3mjJ96MgpbwTn43S1+9yJ0llWygPwDNu2aaWBD6yc9y/Z8XDRNhx7U+u2UDg2OGQXkclUQ==",
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
+			"integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
 			"dev": true,
 			"requires": {
 				"type-detect": "4.0.8"
 			}
 		},
+		"@sinonjs/fake-timers": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+			"integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+			"dev": true,
+			"requires": {
+				"@sinonjs/commons": "^1.7.0"
+			}
+		},
 		"@types/babel__core": {
-			"version": "7.1.6",
-			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.6.tgz",
-			"integrity": "sha512-tTnhWszAqvXnhW7m5jQU9PomXSiKXk2sFxpahXvI20SZKu9ylPi8WtIxueZ6ehDWikPT0jeFujMj3X4ZHuf3Tg==",
+			"version": "7.1.10",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.10.tgz",
+			"integrity": "sha512-x8OM8XzITIMyiwl5Vmo2B1cR1S1Ipkyv4mdlbJjMa1lmuKvKY9FrBbEANIaMlnWn5Rf7uO+rC/VgYabNkE17Hw==",
 			"dev": true,
 			"requires": {
 				"@babel/parser": "^7.1.0",
@@ -1110,18 +1428,18 @@
 			}
 		},
 		"@types/babel__generator": {
-			"version": "7.6.1",
-			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.1.tgz",
-			"integrity": "sha512-bBKm+2VPJcMRVwNhxKu8W+5/zT7pwNEqeokFOmbvVSqGzFneNxYcEBro9Ac7/N9tlsaPYnZLK8J1LWKkMsLAew==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.2.tgz",
+			"integrity": "sha512-MdSJnBjl+bdwkLskZ3NGFp9YcXGx5ggLpQQPqtgakVhsWK0hTtNYhjpZLlWQTviGTvF8at+Bvli3jV7faPdgeQ==",
 			"dev": true,
 			"requires": {
 				"@babel/types": "^7.0.0"
 			}
 		},
 		"@types/babel__template": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.2.tgz",
-			"integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.3.tgz",
+			"integrity": "sha512-uCoznIPDmnickEi6D0v11SBpW0OuVqHJCa7syXqQHy5uktSCreIlt0iglsCnmvz8yCb38hGcWeseA8cWJSwv5Q==",
 			"dev": true,
 			"requires": {
 				"@babel/parser": "^7.1.0",
@@ -1129,9 +1447,9 @@
 			}
 		},
 		"@types/babel__traverse": {
-			"version": "7.0.9",
-			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.9.tgz",
-			"integrity": "sha512-jEFQ8L1tuvPjOI8lnpaf73oCJe+aoxL6ygqSy6c8LcW98zaC+4mzWuQIRCEvKeCOu+lbqdXcg4Uqmm1S8AP1tw==",
+			"version": "7.0.15",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.15.tgz",
+			"integrity": "sha512-Pzh9O3sTK8V6I1olsXpCfj2k/ygO2q1X0vhhnDrEQyYLHZesWz+zMZMVcwXLCYf0U36EtmyYaFGPfXlTtDHe3A==",
 			"dev": true,
 			"requires": {
 				"@babel/types": "^7.3.0"
@@ -1142,6 +1460,15 @@
 			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
 			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
 			"dev": true
+		},
+		"@types/graceful-fs": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.3.tgz",
+			"integrity": "sha512-AiHRaEB50LQg0pZmm659vNBb9f4SJ0qrAnteuzhSeAUcJKxoYgEnprg/83kppCnc2zvtCKbdZry1a5pVY3lOTQ==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
 		},
 		"@types/istanbul-lib-coverage": {
 			"version": "2.0.1",
@@ -1169,15 +1496,33 @@
 			}
 		},
 		"@types/json-schema": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
-			"integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
+			"integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
+			"dev": true
+		},
+		"@types/json5": {
+			"version": "0.0.29",
+			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+			"integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+			"dev": true
+		},
+		"@types/node": {
+			"version": "14.11.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
+			"integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA==",
+			"dev": true
+		},
+		"@types/normalize-package-data": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+			"integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
 			"dev": true
 		},
 		"@types/prettier": {
-			"version": "1.19.1",
-			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.19.1.tgz",
-			"integrity": "sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.1.tgz",
+			"integrity": "sha512-2zs+O+UkDsJ1Vcp667pd3f8xearMdopz/z54i99wtRDI5KLmngk7vlrYZD0ZjKHaROR03EznlBbVY9PfAEyJIQ==",
 			"dev": true
 		},
 		"@types/stack-utils": {
@@ -1202,99 +1547,101 @@
 			"dev": true
 		},
 		"@typescript-eslint/experimental-utils": {
-			"version": "2.25.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.25.0.tgz",
-			"integrity": "sha512-0IZ4ZR5QkFYbaJk+8eJ2kYeA+1tzOE1sBjbwwtSV85oNWYUBep+EyhlZ7DLUCyhMUGuJpcCCFL0fDtYAP1zMZw==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.3.0.tgz",
+			"integrity": "sha512-cmmIK8shn3mxmhpKfzMMywqiEheyfXLV/+yPDnOTvQX/ztngx7Lg/OD26J8gTZfkLKUmaEBxO2jYP3keV7h2OQ==",
 			"dev": true,
 			"requires": {
 				"@types/json-schema": "^7.0.3",
-				"@typescript-eslint/typescript-estree": "2.25.0",
+				"@typescript-eslint/scope-manager": "4.3.0",
+				"@typescript-eslint/types": "4.3.0",
+				"@typescript-eslint/typescript-estree": "4.3.0",
 				"eslint-scope": "^5.0.0",
 				"eslint-utils": "^2.0.0"
-			},
-			"dependencies": {
-				"eslint-utils": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
-					"integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
-					"dev": true,
-					"requires": {
-						"eslint-visitor-keys": "^1.1.0"
-					}
-				}
 			}
+		},
+		"@typescript-eslint/scope-manager": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.3.0.tgz",
+			"integrity": "sha512-cTeyP5SCNE8QBRfc+Lgh4Xpzje46kNUhXYfc3pQWmJif92sjrFuHT9hH4rtOkDTo/si9Klw53yIr+djqGZS1ig==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/types": "4.3.0",
+				"@typescript-eslint/visitor-keys": "4.3.0"
+			}
+		},
+		"@typescript-eslint/types": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.3.0.tgz",
+			"integrity": "sha512-Cx9TpRvlRjOppGsU6Y6KcJnUDOelja2NNCX6AZwtVHRzaJkdytJWMuYiqi8mS35MRNA3cJSwDzXePfmhU6TANw==",
+			"dev": true
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "2.25.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.25.0.tgz",
-			"integrity": "sha512-VUksmx5lDxSi6GfmwSK7SSoIKSw9anukWWNitQPqt58LuYrKalzsgeuignbqnB+rK/xxGlSsCy8lYnwFfB6YJg==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.3.0.tgz",
+			"integrity": "sha512-ZAI7xjkl+oFdLV/COEz2tAbQbR3XfgqHEGy0rlUXzfGQic6EBCR4s2+WS3cmTPG69aaZckEucBoTxW9PhzHxxw==",
 			"dev": true,
 			"requires": {
+				"@typescript-eslint/types": "4.3.0",
+				"@typescript-eslint/visitor-keys": "4.3.0",
 				"debug": "^4.1.1",
-				"eslint-visitor-keys": "^1.1.0",
-				"glob": "^7.1.6",
+				"globby": "^11.0.1",
 				"is-glob": "^4.0.1",
 				"lodash": "^4.17.15",
-				"semver": "^6.3.0",
+				"semver": "^7.3.2",
 				"tsutils": "^3.17.1"
-			},
-			"dependencies": {
-				"glob": {
-					"version": "7.1.6",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-					"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-					"dev": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				}
 			}
 		},
-		"abab": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
-			"integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==",
-			"dev": true
-		},
-		"acorn": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
-			"integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
-			"dev": true
-		},
-		"acorn-globals": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
-			"integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
+		"@typescript-eslint/visitor-keys": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.3.0.tgz",
+			"integrity": "sha512-xZxkuR7XLM6RhvLkgv9yYlTcBHnTULzfnw4i6+z2TGBLy9yljAypQaZl9c3zFvy7PNI7fYWyvKYtohyF8au3cw==",
 			"dev": true,
 			"requires": {
-				"acorn": "^6.0.1",
-				"acorn-walk": "^6.0.1"
+				"@typescript-eslint/types": "4.3.0",
+				"eslint-visitor-keys": "^2.0.0"
 			},
 			"dependencies": {
-				"acorn": {
-					"version": "6.4.1",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
-					"integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
+				"eslint-visitor-keys": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
+					"integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
 					"dev": true
 				}
 			}
 		},
+		"abab": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
+			"integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
+			"dev": true
+		},
+		"acorn": {
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
+			"integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
+			"dev": true
+		},
+		"acorn-globals": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
+			"integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
+			"dev": true,
+			"requires": {
+				"acorn": "^7.1.1",
+				"acorn-walk": "^7.1.1"
+			}
+		},
 		"acorn-jsx": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
-			"integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==",
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
+			"integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
 			"dev": true
 		},
 		"acorn-walk": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
-			"integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+			"integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
 			"dev": true
 		},
 		"ajv": {
@@ -1308,6 +1655,12 @@
 				"json-schema-traverse": "^0.4.1",
 				"uri-js": "^4.2.2"
 			}
+		},
+		"ansi-colors": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+			"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+			"dev": true
 		},
 		"ansi-escape-sequences": {
 			"version": "4.1.0",
@@ -1378,13 +1731,13 @@
 			}
 		},
 		"aria-query": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz",
-			"integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
+			"integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
 			"dev": true,
 			"requires": {
-				"ast-types-flow": "0.0.7",
-				"commander": "^2.11.0"
+				"@babel/runtime": "^7.10.2",
+				"@babel/runtime-corejs3": "^7.10.2"
 			}
 		},
 		"arr-diff": {
@@ -1411,12 +1764,6 @@
 			"integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg==",
 			"dev": true
 		},
-		"array-equal": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
-			"dev": true
-		},
 		"array-includes": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.1.tgz",
@@ -1429,83 +1776,31 @@
 			},
 			"dependencies": {
 				"es-abstract": {
-					"version": "1.17.4",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
-					"integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
+					"version": "1.17.7",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+					"integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
 					"dev": true,
 					"requires": {
 						"es-to-primitive": "^1.2.1",
 						"function-bind": "^1.1.1",
 						"has": "^1.0.3",
 						"has-symbols": "^1.0.1",
-						"is-callable": "^1.1.5",
-						"is-regex": "^1.0.5",
-						"object-inspect": "^1.7.0",
+						"is-callable": "^1.2.2",
+						"is-regex": "^1.1.1",
+						"object-inspect": "^1.8.0",
 						"object-keys": "^1.1.1",
-						"object.assign": "^4.1.0",
-						"string.prototype.trimleft": "^2.1.1",
-						"string.prototype.trimright": "^2.1.1"
-					}
-				},
-				"es-to-primitive": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-					"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-					"dev": true,
-					"requires": {
-						"is-callable": "^1.1.4",
-						"is-date-object": "^1.0.1",
-						"is-symbol": "^1.0.2"
-					}
-				},
-				"has-symbols": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-					"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-					"dev": true
-				},
-				"is-callable": {
-					"version": "1.1.5",
-					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-					"integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
-					"dev": true
-				},
-				"is-regex": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
-					"integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
-					"dev": true,
-					"requires": {
-						"has": "^1.0.3"
-					}
-				},
-				"object-inspect": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-					"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
-					"dev": true
-				},
-				"string.prototype.trimleft": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
-					"integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
-					"dev": true,
-					"requires": {
-						"define-properties": "^1.1.3",
-						"function-bind": "^1.1.1"
-					}
-				},
-				"string.prototype.trimright": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
-					"integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
-					"dev": true,
-					"requires": {
-						"define-properties": "^1.1.3",
-						"function-bind": "^1.1.1"
+						"object.assign": "^4.1.1",
+						"string.prototype.trimend": "^1.0.1",
+						"string.prototype.trimstart": "^1.0.1"
 					}
 				}
 			}
+		},
+		"array-union": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+			"dev": true
 		},
 		"array-unique": {
 			"version": "0.3.2",
@@ -1524,80 +1819,22 @@
 			},
 			"dependencies": {
 				"es-abstract": {
-					"version": "1.17.4",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
-					"integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
+					"version": "1.17.7",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+					"integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
 					"dev": true,
 					"requires": {
 						"es-to-primitive": "^1.2.1",
 						"function-bind": "^1.1.1",
 						"has": "^1.0.3",
 						"has-symbols": "^1.0.1",
-						"is-callable": "^1.1.5",
-						"is-regex": "^1.0.5",
-						"object-inspect": "^1.7.0",
+						"is-callable": "^1.2.2",
+						"is-regex": "^1.1.1",
+						"object-inspect": "^1.8.0",
 						"object-keys": "^1.1.1",
-						"object.assign": "^4.1.0",
-						"string.prototype.trimleft": "^2.1.1",
-						"string.prototype.trimright": "^2.1.1"
-					}
-				},
-				"es-to-primitive": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-					"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-					"dev": true,
-					"requires": {
-						"is-callable": "^1.1.4",
-						"is-date-object": "^1.0.1",
-						"is-symbol": "^1.0.2"
-					}
-				},
-				"has-symbols": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-					"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-					"dev": true
-				},
-				"is-callable": {
-					"version": "1.1.5",
-					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-					"integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
-					"dev": true
-				},
-				"is-regex": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
-					"integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
-					"dev": true,
-					"requires": {
-						"has": "^1.0.3"
-					}
-				},
-				"object-inspect": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-					"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
-					"dev": true
-				},
-				"string.prototype.trimleft": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
-					"integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
-					"dev": true,
-					"requires": {
-						"define-properties": "^1.1.3",
-						"function-bind": "^1.1.1"
-					}
-				},
-				"string.prototype.trimright": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
-					"integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
-					"dev": true,
-					"requires": {
-						"define-properties": "^1.1.3",
-						"function-bind": "^1.1.1"
+						"object.assign": "^4.1.1",
+						"string.prototype.trimend": "^1.0.1",
+						"string.prototype.trimstart": "^1.0.1"
 					}
 				}
 			}
@@ -1654,48 +1891,65 @@
 			"dev": true
 		},
 		"aws4": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+			"version": "1.10.1",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
+			"integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==",
+			"dev": true
+		},
+		"axe-core": {
+			"version": "3.5.5",
+			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.5.tgz",
+			"integrity": "sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==",
 			"dev": true
 		},
 		"axobject-query": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.1.2.tgz",
-			"integrity": "sha512-ICt34ZmrVt8UQnvPl6TVyDTkmhXmAyAT4Jh5ugfGUX4MOrZ+U/ZY6/sdylRw3qGNr9Ub5AJsaHeDMzNLehRdOQ==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
+			"integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==",
 			"dev": true
 		},
 		"babel-jest": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-25.2.1.tgz",
-			"integrity": "sha512-OiBpQGYtV4rWMuFneIaEsqJB0VdoOBw4SqwO4hA2EhDY/O8RylQ20JwALkxv8iv+CYnyrZZfF+DELPgrdrkRIw==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.3.0.tgz",
+			"integrity": "sha512-sxPnQGEyHAOPF8NcUsD0g7hDCnvLL2XyblRBcgrzTWBB/mAIpWow3n1bEL+VghnnZfreLhFSBsFluRoK2tRK4g==",
 			"dev": true,
 			"requires": {
-				"@jest/transform": "^25.2.1",
-				"@jest/types": "^25.2.1",
-				"@types/babel__core": "^7.1.0",
+				"@jest/transform": "^26.3.0",
+				"@jest/types": "^26.3.0",
+				"@types/babel__core": "^7.1.7",
 				"babel-plugin-istanbul": "^6.0.0",
-				"babel-preset-jest": "^25.2.1",
-				"chalk": "^3.0.0",
+				"babel-preset-jest": "^26.3.0",
+				"chalk": "^4.0.0",
+				"graceful-fs": "^4.2.4",
 				"slash": "^3.0.0"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-25.2.1.tgz",
-					"integrity": "sha512-WuGFGJ3Rrycg+5ZwQTWKjr21M9psANPAWYD28K42hSeUzhv1H591VXIoq0tjs00mydhNOgVOkKSpzRS3CrOYFw==",
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^1.1.1",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
 						"@types/yargs": "^15.0.0",
-						"chalk": "^3.0.0"
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.4",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-					"integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+					"version": "15.0.7",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
+					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -1712,9 +1966,9 @@
 					}
 				},
 				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
@@ -1743,9 +1997,9 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -1767,23 +2021,44 @@
 			}
 		},
 		"babel-plugin-jest-hoist": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-25.2.1.tgz",
-			"integrity": "sha512-HysbCQfJhxLlyxDbKcB2ucGYV0LjqK4h6dBoI3RtFuOxTiTWK6XGZMsHb0tGh8iJdV4hC6Z2GCHzVvDeh9i0lQ==",
+			"version": "26.2.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.2.0.tgz",
+			"integrity": "sha512-B/hVMRv8Nh1sQ1a3EY8I0n4Y1Wty3NrR5ebOyVT302op+DOAau+xNEImGMsUWOC3++ZlMooCytKz+NgN8aKGbA==",
 			"dev": true,
 			"requires": {
+				"@babel/template": "^7.3.3",
+				"@babel/types": "^7.3.3",
+				"@types/babel__core": "^7.0.0",
 				"@types/babel__traverse": "^7.0.6"
 			}
 		},
-		"babel-preset-jest": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-25.2.1.tgz",
-			"integrity": "sha512-zXHJBM5iR8oEO4cvdF83AQqqJf3tJrXy3x8nfu2Nlqvn4cneg4Ca8M7cQvC5S9BzDDy1O0tZ9iXru9J6E3ym+A==",
+		"babel-preset-current-node-syntax": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.3.tgz",
+			"integrity": "sha512-uyexu1sVwcdFnyq9o8UQYsXwXflIh8LvrF5+cKrYam93ned1CStffB3+BEcsxGSgagoA3GEyjDqO4a/58hyPYQ==",
 			"dev": true,
 			"requires": {
-				"@babel/plugin-syntax-bigint": "^7.0.0",
-				"@babel/plugin-syntax-object-rest-spread": "^7.0.0",
-				"babel-plugin-jest-hoist": "^25.2.1"
+				"@babel/plugin-syntax-async-generators": "^7.8.4",
+				"@babel/plugin-syntax-bigint": "^7.8.3",
+				"@babel/plugin-syntax-class-properties": "^7.8.3",
+				"@babel/plugin-syntax-import-meta": "^7.8.3",
+				"@babel/plugin-syntax-json-strings": "^7.8.3",
+				"@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+				"@babel/plugin-syntax-numeric-separator": "^7.8.3",
+				"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+				"@babel/plugin-syntax-optional-chaining": "^7.8.3"
+			}
+		},
+		"babel-preset-jest": {
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.3.0.tgz",
+			"integrity": "sha512-5WPdf7nyYi2/eRxCbVrE1kKCWxgWY4RsPEbdJWFm7QsesFGqjdkyLeu1zRkwM1cxK6EPIlNd6d2AxLk7J+t4pw==",
+			"dev": true,
+			"requires": {
+				"babel-plugin-jest-hoist": "^26.2.0",
+				"babel-preset-current-node-syntax": "^0.1.3"
 			}
 		},
 		"balanced-match": {
@@ -1887,23 +2162,6 @@
 			"integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
 			"dev": true
 		},
-		"browser-resolve": {
-			"version": "1.11.3",
-			"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
-			"integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
-			"dev": true,
-			"requires": {
-				"resolve": "1.1.7"
-			},
-			"dependencies": {
-				"resolve": {
-					"version": "1.1.7",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-					"dev": true
-				}
-			}
-		},
 		"bser": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
@@ -1937,12 +2195,12 @@
 			}
 		},
 		"cache-point": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/cache-point/-/cache-point-1.0.0.tgz",
-			"integrity": "sha512-ZqrZp9Hi5Uq7vfSGmNP2bUT/9DzZC2Y/GXjHB8rUJN1a+KLmbV05+vxHipNsg8+CSVgjcVVzLV8VZms6w8ZeRw==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/cache-point/-/cache-point-2.0.0.tgz",
+			"integrity": "sha512-4gkeHlFpSKgm3vm2gJN5sPqfmijYRFYCQ6tv5cLw0xVmT6r1z1vd4FNnpuOREco3cBs1G709sZ72LdgddKvL5w==",
 			"dev": true,
 			"requires": {
-				"array-back": "^4.0.0",
+				"array-back": "^4.0.1",
 				"fs-then-native": "^2.0.0",
 				"mkdirp2": "^1.0.4"
 			}
@@ -1994,10 +2252,10 @@
 				"supports-color": "^5.3.0"
 			}
 		},
-		"chardet": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+		"char-regex": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+			"integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
 			"dev": true
 		},
 		"ci-info": {
@@ -2029,21 +2287,6 @@
 				}
 			}
 		},
-		"cli-cursor": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-			"integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-			"dev": true,
-			"requires": {
-				"restore-cursor": "^3.1.0"
-			}
-		},
-		"cli-width": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
-			"dev": true
-		},
 		"cliui": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -2055,13 +2298,27 @@
 				"wrap-ansi": "^6.2.0"
 			},
 			"dependencies": {
-				"strip-ansi": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^5.0.0"
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.0"
 					}
 				}
 			}
@@ -2073,9 +2330,9 @@
 			"dev": true
 		},
 		"collect-all": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/collect-all/-/collect-all-1.0.3.tgz",
-			"integrity": "sha512-0y0rBgoX8IzIjBAUnO73SEtSb4Mhk3IoceWJq5zZSxb9mWORhWH8xLYo4EDSOE1jRBk1LhmfjqWFFt10h/+MEA==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/collect-all/-/collect-all-1.0.4.tgz",
+			"integrity": "sha512-RKZhRwJtJEP5FWul+gkSMEnaK6H3AGPTTWOiRimCcs+rc/OmQE3Yhy1Q7A7KsdkG3ZXVdZq68Y6ONSdvkeEcKA==",
 			"dev": true,
 			"requires": {
 				"stream-connect": "^1.0.2",
@@ -2083,9 +2340,9 @@
 			}
 		},
 		"collect-v8-coverage": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.0.tgz",
-			"integrity": "sha512-VKIhJgvk8E1W28m5avZ2Gv2Ruv5YiF56ug2oclvaG9md69BuZImMG2sk9g7QNKLUbtYAKQjXjYxbYZVUlMMKmQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
+			"integrity": "sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==",
 			"dev": true
 		},
 		"collection-visit": {
@@ -2195,12 +2452,6 @@
 				}
 			}
 		},
-		"commander": {
-			"version": "2.20.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-			"dev": true
-		},
 		"common-sequence": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/common-sequence/-/common-sequence-2.0.0.tgz",
@@ -2263,6 +2514,12 @@
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
 			"dev": true
 		},
+		"core-js-pure": {
+			"version": "3.6.5",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz",
+			"integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==",
+			"dev": true
+		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -2270,24 +2527,14 @@
 			"dev": true
 		},
 		"cross-spawn": {
-			"version": "6.0.5",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-			"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
 			"dev": true,
 			"requires": {
-				"nice-try": "^1.0.4",
-				"path-key": "^2.0.1",
-				"semver": "^5.5.0",
-				"shebang-command": "^1.2.0",
-				"which": "^1.2.9"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
-				}
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
 			}
 		},
 		"cssom": {
@@ -2297,9 +2544,9 @@
 			"dev": true
 		},
 		"cssstyle": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.2.0.tgz",
-			"integrity": "sha512-sEb3XFPx3jNnCAMtqrXPDeSgQr+jojtCeNf8cvMNMh1cG970+lljssvQDzPq6lmmJu2Vhqood/gtEomBiHOGnA==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+			"integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
 			"dev": true,
 			"requires": {
 				"cssom": "~0.3.6"
@@ -2329,29 +2576,35 @@
 			}
 		},
 		"data-urls": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
-			"integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
+			"integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
 			"dev": true,
 			"requires": {
-				"abab": "^2.0.0",
-				"whatwg-mimetype": "^2.2.0",
-				"whatwg-url": "^7.0.0"
+				"abab": "^2.0.3",
+				"whatwg-mimetype": "^2.3.0",
+				"whatwg-url": "^8.0.0"
 			}
 		},
 		"debug": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+			"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
 			"dev": true,
 			"requires": {
-				"ms": "^2.1.1"
+				"ms": "2.1.2"
 			}
 		},
 		"decamelize": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+			"dev": true
+		},
+		"decimal.js": {
+			"version": "10.2.1",
+			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
+			"integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw==",
 			"dev": true
 		},
 		"decode-uri-component": {
@@ -2446,19 +2699,36 @@
 			"integrity": "sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==",
 			"dev": true
 		},
+		"dir-glob": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+			"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+			"dev": true,
+			"requires": {
+				"path-type": "^4.0.0"
+			},
+			"dependencies": {
+				"path-type": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+					"dev": true
+				}
+			}
+		},
 		"dmd": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/dmd/-/dmd-4.0.6.tgz",
-			"integrity": "sha512-7ZYAnFQ6jGm4SICArwqNPylJ83PaOdPTAkds3Z/s1ueFqSc5ilJ2F0b7uP+35W1PUbemH++gn5/VlC3KwEgiHQ==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/dmd/-/dmd-5.0.2.tgz",
+			"integrity": "sha512-npXsE2+/onRPk/LCrUmx7PcUSqcSVnbrDDMi2nBSawNZ8QXlHE/8xaEZ6pNqPD1lQZv8LGr1xEIpyxP336xyfw==",
 			"dev": true,
 			"requires": {
 				"array-back": "^4.0.1",
-				"cache-point": "^1.0.0",
+				"cache-point": "^2.0.0",
 				"common-sequence": "^2.0.0",
-				"file-set": "^3.0.0",
-				"handlebars": "^4.5.3",
-				"marked": "^0.7.0",
-				"object-get": "^2.1.0",
+				"file-set": "^4.0.1",
+				"handlebars": "^4.7.6",
+				"marked": "^1.1.0",
+				"object-get": "^2.1.1",
 				"reduce-flatten": "^3.0.0",
 				"reduce-unique": "^2.0.1",
 				"reduce-without": "^1.0.1",
@@ -2484,12 +2754,20 @@
 			}
 		},
 		"domexception": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
-			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
+			"integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
 			"dev": true,
 			"requires": {
-				"webidl-conversions": "^4.0.2"
+				"webidl-conversions": "^5.0.0"
+			},
+			"dependencies": {
+				"webidl-conversions": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+					"integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
+					"dev": true
+				}
 			}
 		},
 		"ecc-jsbn": {
@@ -2501,6 +2779,12 @@
 				"jsbn": "~0.1.0",
 				"safer-buffer": "^2.1.0"
 			}
+		},
+		"emittery": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/emittery/-/emittery-0.7.1.tgz",
+			"integrity": "sha512-d34LN4L6h18Bzz9xpoku2nPwKxCPlPMr3EEKTkoEBi+1/+b0lcRkRJ1UVyyZaKNeqGR3swcGl6s390DNO4YVgQ==",
+			"dev": true
 		},
 		"emoji-regex": {
 			"version": "7.0.3",
@@ -2515,6 +2799,15 @@
 			"dev": true,
 			"requires": {
 				"once": "^1.4.0"
+			}
+		},
+		"enquirer": {
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+			"integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+			"dev": true,
+			"requires": {
+				"ansi-colors": "^4.1.1"
 			}
 		},
 		"entities": {
@@ -2533,30 +2826,23 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.17.5",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
-			"integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+			"version": "1.18.0-next.1",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+			"integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
 			"dev": true,
 			"requires": {
 				"es-to-primitive": "^1.2.1",
 				"function-bind": "^1.1.1",
 				"has": "^1.0.3",
 				"has-symbols": "^1.0.1",
-				"is-callable": "^1.1.5",
-				"is-regex": "^1.0.5",
-				"object-inspect": "^1.7.0",
+				"is-callable": "^1.2.2",
+				"is-negative-zero": "^2.0.0",
+				"is-regex": "^1.1.1",
+				"object-inspect": "^1.8.0",
 				"object-keys": "^1.1.1",
-				"object.assign": "^4.1.0",
-				"string.prototype.trimleft": "^2.1.1",
-				"string.prototype.trimright": "^2.1.1"
-			},
-			"dependencies": {
-				"has-symbols": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-					"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-					"dev": true
-				}
+				"object.assign": "^4.1.1",
+				"string.prototype.trimend": "^1.0.1",
+				"string.prototype.trimstart": "^1.0.1"
 			}
 		},
 		"es-to-primitive": {
@@ -2577,9 +2863,9 @@
 			"dev": true
 		},
 		"escodegen": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.1.tgz",
-			"integrity": "sha512-Bmt7NcRySdIfNPfU2ZoXDrrXsG9ZjvDxcAlMfDUgRBjLOWTuIACXPBFJH7Z+cLb40JeQco5toikyc9t9P8E9SQ==",
+			"version": "1.14.3",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+			"integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
 			"dev": true,
 			"requires": {
 				"esprima": "^4.0.1",
@@ -2587,60 +2873,16 @@
 				"esutils": "^2.0.2",
 				"optionator": "^0.8.1",
 				"source-map": "~0.6.1"
-			}
-		},
-		"eslint": {
-			"version": "6.8.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
-			"integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
-			"dev": true,
-			"requires": {
-				"@babel/code-frame": "^7.0.0",
-				"ajv": "^6.10.0",
-				"chalk": "^2.1.0",
-				"cross-spawn": "^6.0.5",
-				"debug": "^4.0.1",
-				"doctrine": "^3.0.0",
-				"eslint-scope": "^5.0.0",
-				"eslint-utils": "^1.4.3",
-				"eslint-visitor-keys": "^1.1.0",
-				"espree": "^6.1.2",
-				"esquery": "^1.0.1",
-				"esutils": "^2.0.2",
-				"file-entry-cache": "^5.0.1",
-				"functional-red-black-tree": "^1.0.1",
-				"glob-parent": "^5.0.0",
-				"globals": "^12.1.0",
-				"ignore": "^4.0.6",
-				"import-fresh": "^3.0.0",
-				"imurmurhash": "^0.1.4",
-				"inquirer": "^7.0.0",
-				"is-glob": "^4.0.0",
-				"js-yaml": "^3.13.1",
-				"json-stable-stringify-without-jsonify": "^1.0.1",
-				"levn": "^0.3.0",
-				"lodash": "^4.17.14",
-				"minimatch": "^3.0.4",
-				"mkdirp": "^0.5.1",
-				"natural-compare": "^1.4.0",
-				"optionator": "^0.8.3",
-				"progress": "^2.0.0",
-				"regexpp": "^2.0.1",
-				"semver": "^6.1.2",
-				"strip-ansi": "^5.2.0",
-				"strip-json-comments": "^3.0.1",
-				"table": "^5.2.3",
-				"text-table": "^0.2.0",
-				"v8-compile-cache": "^2.0.3"
 			},
 			"dependencies": {
-				"globals": {
-					"version": "12.3.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-12.3.0.tgz",
-					"integrity": "sha512-wAfjdLgFsPZsklLJvOBUBmzYE8/CwhEqSBEMRXA3qxIiNtyqvjYurAtIfDh6chlEPUfmTY3MnZh5Hfh4q0UlIw==",
+				"levn": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+					"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
 					"dev": true,
 					"requires": {
-						"type-fest": "^0.8.1"
+						"prelude-ls": "~1.1.2",
+						"type-check": "~0.3.2"
 					}
 				},
 				"optionator": {
@@ -2656,33 +2898,145 @@
 						"type-check": "~0.3.2",
 						"word-wrap": "~1.2.3"
 					}
+				},
+				"prelude-ls": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+					"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+					"dev": true
+				},
+				"type-check": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+					"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+					"dev": true,
+					"requires": {
+						"prelude-ls": "~1.1.2"
+					}
+				}
+			}
+		},
+		"eslint": {
+			"version": "7.10.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.10.0.tgz",
+			"integrity": "sha512-BDVffmqWl7JJXqCjAK6lWtcQThZB/aP1HXSH1JKwGwv0LQEdvpR7qzNrUT487RM39B5goWuboFad5ovMBmD8yA==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@eslint/eslintrc": "^0.1.3",
+				"ajv": "^6.10.0",
+				"chalk": "^4.0.0",
+				"cross-spawn": "^7.0.2",
+				"debug": "^4.0.1",
+				"doctrine": "^3.0.0",
+				"enquirer": "^2.3.5",
+				"eslint-scope": "^5.1.1",
+				"eslint-utils": "^2.1.0",
+				"eslint-visitor-keys": "^1.3.0",
+				"espree": "^7.3.0",
+				"esquery": "^1.2.0",
+				"esutils": "^2.0.2",
+				"file-entry-cache": "^5.0.1",
+				"functional-red-black-tree": "^1.0.1",
+				"glob-parent": "^5.0.0",
+				"globals": "^12.1.0",
+				"ignore": "^4.0.6",
+				"import-fresh": "^3.0.0",
+				"imurmurhash": "^0.1.4",
+				"is-glob": "^4.0.0",
+				"js-yaml": "^3.13.1",
+				"json-stable-stringify-without-jsonify": "^1.0.1",
+				"levn": "^0.4.1",
+				"lodash": "^4.17.19",
+				"minimatch": "^3.0.4",
+				"natural-compare": "^1.4.0",
+				"optionator": "^0.9.1",
+				"progress": "^2.0.0",
+				"regexpp": "^3.1.0",
+				"semver": "^7.2.1",
+				"strip-ansi": "^6.0.0",
+				"strip-json-comments": "^3.1.0",
+				"table": "^5.2.3",
+				"text-table": "^0.2.0",
+				"v8-compile-cache": "^2.0.3"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
 				}
 			}
 		},
 		"eslint-config-airbnb-base": {
-			"version": "14.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.1.0.tgz",
-			"integrity": "sha512-+XCcfGyCnbzOnktDVhwsCAx+9DmrzEmuwxyHUJpw+kqBVT744OUBrB09khgFKlK1lshVww6qXGsYPZpavoNjJw==",
+			"version": "14.2.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.0.tgz",
+			"integrity": "sha512-Snswd5oC6nJaevs3nZoLSTvGJBvzTfnBqOIArkf3cbyTyq9UD79wOk8s+RiL6bhca0p/eRO6veczhf6A/7Jy8Q==",
 			"dev": true,
 			"requires": {
 				"confusing-browser-globals": "^1.0.9",
 				"object.assign": "^4.1.0",
-				"object.entries": "^1.1.1"
+				"object.entries": "^1.1.2"
 			}
 		},
 		"eslint-config-prettier": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.0.tgz",
-			"integrity": "sha512-AtndijGte1rPILInUdHjvKEGbIV06NuvPrqlIEaEaWtbtvJh464mDeyGMdZEQMsGvC0ZVkiex1fSNcC4HAbRGg==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.12.0.tgz",
+			"integrity": "sha512-9jWPlFlgNwRUYVoujvWTQ1aMO8o6648r+K7qU7K5Jmkbyqav1fuEZC0COYpGBxyiAJb65Ra9hrmFx19xRGwXWw==",
 			"dev": true,
 			"requires": {
 				"get-stdin": "^6.0.0"
 			}
 		},
 		"eslint-import-resolver-node": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.3.tgz",
-			"integrity": "sha512-b8crLDo0M5RSe5YG8Pu2DYBj71tSB6OvXkfzwbJU2w7y8P4/yo0MyF8jU26IEuEuHF2K5/gcAJE3LhQGqBBbVg==",
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz",
+			"integrity": "sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==",
 			"dev": true,
 			"requires": {
 				"debug": "^2.6.9",
@@ -2703,22 +3057,13 @@
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 					"dev": true
-				},
-				"resolve": {
-					"version": "1.15.1",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
-					"integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
-					"dev": true,
-					"requires": {
-						"path-parse": "^1.0.6"
-					}
 				}
 			}
 		},
 		"eslint-module-utils": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.5.2.tgz",
-			"integrity": "sha512-LGScZ/JSlqGKiT8OC+cYRxseMjyqt6QO54nl281CK93unD89ijSeRV6An8Ci/2nvWVKe8K/Tqdm75RQoIOCr+Q==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
+			"integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
 			"dev": true,
 			"requires": {
 				"debug": "^2.6.9",
@@ -2734,84 +3079,33 @@
 						"ms": "2.0.0"
 					}
 				},
-				"find-up": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-					"dev": true,
-					"requires": {
-						"locate-path": "^2.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-					"dev": true,
-					"requires": {
-						"p-locate": "^2.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 					"dev": true
-				},
-				"p-limit": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-					"dev": true,
-					"requires": {
-						"p-try": "^1.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-					"dev": true,
-					"requires": {
-						"p-limit": "^1.1.0"
-					}
-				},
-				"p-try": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-					"dev": true
-				},
-				"pkg-dir": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
-					"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
-					"dev": true,
-					"requires": {
-						"find-up": "^2.1.0"
-					}
 				}
 			}
 		},
 		"eslint-plugin-import": {
-			"version": "2.20.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.20.1.tgz",
-			"integrity": "sha512-qQHgFOTjguR+LnYRoToeZWT62XM55MBVXObHM6SKFd1VzDcX/vqT1kAz8ssqigh5eMj8qXcRoXXGZpPP6RfdCw==",
+			"version": "2.22.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz",
+			"integrity": "sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==",
 			"dev": true,
 			"requires": {
-				"array-includes": "^3.0.3",
-				"array.prototype.flat": "^1.2.1",
+				"array-includes": "^3.1.1",
+				"array.prototype.flat": "^1.2.3",
 				"contains-path": "^0.1.0",
 				"debug": "^2.6.9",
 				"doctrine": "1.5.0",
-				"eslint-import-resolver-node": "^0.3.2",
-				"eslint-module-utils": "^2.4.1",
+				"eslint-import-resolver-node": "^0.3.4",
+				"eslint-module-utils": "^2.6.0",
 				"has": "^1.0.3",
 				"minimatch": "^3.0.4",
-				"object.values": "^1.1.0",
+				"object.values": "^1.1.1",
 				"read-pkg-up": "^2.0.0",
-				"resolve": "^1.12.0"
+				"resolve": "^1.17.0",
+				"tsconfig-paths": "^3.9.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -2833,144 +3127,54 @@
 						"isarray": "^1.0.0"
 					}
 				},
-				"find-up": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-					"dev": true,
-					"requires": {
-						"locate-path": "^2.0.0"
-					}
-				},
-				"load-json-file": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^2.2.0",
-						"pify": "^2.0.0",
-						"strip-bom": "^3.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-					"dev": true,
-					"requires": {
-						"p-locate": "^2.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 					"dev": true
-				},
-				"p-limit": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-					"dev": true,
-					"requires": {
-						"p-try": "^1.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-					"dev": true,
-					"requires": {
-						"p-limit": "^1.1.0"
-					}
-				},
-				"p-try": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-					"dev": true
-				},
-				"parse-json": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-					"dev": true,
-					"requires": {
-						"error-ex": "^1.2.0"
-					}
-				},
-				"path-type": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-					"dev": true,
-					"requires": {
-						"pify": "^2.0.0"
-					}
-				},
-				"pify": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
-				},
-				"read-pkg": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-					"dev": true,
-					"requires": {
-						"load-json-file": "^2.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^2.0.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-					"dev": true,
-					"requires": {
-						"find-up": "^2.0.0",
-						"read-pkg": "^2.0.0"
-					}
 				}
 			}
 		},
 		"eslint-plugin-jest": {
-			"version": "23.8.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-23.8.2.tgz",
-			"integrity": "sha512-xwbnvOsotSV27MtAe7s8uGWOori0nUsrXh2f1EnpmXua8sDfY6VZhHAhHg2sqK7HBNycRQExF074XSZ7DvfoFg==",
+			"version": "24.0.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.0.2.tgz",
+			"integrity": "sha512-DSBLNpkKDOpUJQkTGSs5sVJWsu0nDyQ2rYxkr0Eh7nrkc5bMUr/dlDbtTj3l8y6UaCVsem6rryF1OZrKnz1S5g==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/experimental-utils": "^2.5.0"
+				"@typescript-eslint/experimental-utils": "^4.0.1"
 			}
 		},
 		"eslint-plugin-jsx-a11y": {
-			"version": "6.2.3",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.3.tgz",
-			"integrity": "sha512-CawzfGt9w83tyuVekn0GDPU9ytYtxyxyFZ3aSWROmnRRFQFT2BiPJd7jvRdzNDi6oLWaS2asMeYSNMjWTV4eNg==",
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.3.1.tgz",
+			"integrity": "sha512-i1S+P+c3HOlBJzMFORRbC58tHa65Kbo8b52/TwCwSKLohwvpfT5rm2GjGWzOHTEuq4xxf2aRlHHTtmExDQOP+g==",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "^7.4.5",
-				"aria-query": "^3.0.0",
-				"array-includes": "^3.0.3",
+				"@babel/runtime": "^7.10.2",
+				"aria-query": "^4.2.2",
+				"array-includes": "^3.1.1",
 				"ast-types-flow": "^0.0.7",
-				"axobject-query": "^2.0.2",
-				"damerau-levenshtein": "^1.0.4",
-				"emoji-regex": "^7.0.2",
+				"axe-core": "^3.5.4",
+				"axobject-query": "^2.1.2",
+				"damerau-levenshtein": "^1.0.6",
+				"emoji-regex": "^9.0.0",
 				"has": "^1.0.3",
-				"jsx-ast-utils": "^2.2.1"
+				"jsx-ast-utils": "^2.4.1",
+				"language-tags": "^1.0.5"
+			},
+			"dependencies": {
+				"emoji-regex": {
+					"version": "9.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.0.0.tgz",
+					"integrity": "sha512-6p1NII1Vm62wni/VR/cUMauVQoxmLVb9csqQlvLz+hO2gk8U2UYDfXHQSUYIBKmZwAKz867IDqG7B+u0mj+M6w==",
+					"dev": true
+				}
 			}
 		},
 		"eslint-plugin-prettier": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.2.tgz",
-			"integrity": "sha512-GlolCC9y3XZfv3RQfwGew7NnuFDKsfI4lbvRK+PIIo23SFH+LemGs4cKwzAaRa+Mdb+lQO/STaIayno8T5sJJA==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.4.tgz",
+			"integrity": "sha512-jZDa8z76klRqo+TdGDTFJSavwbnWK2ZpqGKNZ+VvweMW516pDUMmQ2koXvxEE4JhzNvTv+radye/bWGBmA6jmg==",
 			"dev": true,
 			"requires": {
 				"prettier-linter-helpers": "^1.0.0"
@@ -2983,39 +3187,39 @@
 			"dev": true
 		},
 		"eslint-scope": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
-			"integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
 			"dev": true,
 			"requires": {
-				"esrecurse": "^4.1.0",
+				"esrecurse": "^4.3.0",
 				"estraverse": "^4.1.1"
 			}
 		},
 		"eslint-utils": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
-			"integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+			"integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
 			"dev": true,
 			"requires": {
 				"eslint-visitor-keys": "^1.1.0"
 			}
 		},
 		"eslint-visitor-keys": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-			"integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+			"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
 			"dev": true
 		},
 		"espree": {
-			"version": "6.1.2",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
-			"integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-7.3.0.tgz",
+			"integrity": "sha512-dksIWsvKCixn1yrEXO8UosNSxaDoSYpq9reEjZSbHLpT5hpaCAKTLBwq0RHtLrIr+c0ByiYzWT8KTMRzoRCNlw==",
 			"dev": true,
 			"requires": {
-				"acorn": "^7.1.0",
-				"acorn-jsx": "^5.1.0",
-				"eslint-visitor-keys": "^1.1.0"
+				"acorn": "^7.4.0",
+				"acorn-jsx": "^5.2.0",
+				"eslint-visitor-keys": "^1.3.0"
 			}
 		},
 		"esprima": {
@@ -3025,21 +3229,37 @@
 			"dev": true
 		},
 		"esquery": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.1.0.tgz",
-			"integrity": "sha512-MxYW9xKmROWF672KqjO75sszsA8Mxhw06YFeS5VHlB98KDHbOSurm3ArsjO60Eaf3QmGMCP1yn+0JQkNLo/97Q==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
+			"integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
 			"dev": true,
 			"requires": {
-				"estraverse": "^4.0.0"
+				"estraverse": "^5.1.0"
+			},
+			"dependencies": {
+				"estraverse": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+					"integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+					"dev": true
+				}
 			}
 		},
 		"esrecurse": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
 			"dev": true,
 			"requires": {
-				"estraverse": "^4.1.0"
+				"estraverse": "^5.2.0"
+			},
+			"dependencies": {
+				"estraverse": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+					"integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+					"dev": true
+				}
 			}
 		},
 		"estraverse": {
@@ -3073,6 +3293,57 @@
 				"p-finally": "^1.0.0",
 				"signal-exit": "^3.0.0",
 				"strip-eof": "^1.0.0"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "6.0.5",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+					"dev": true,
+					"requires": {
+						"nice-try": "^1.0.4",
+						"path-key": "^2.0.1",
+						"semver": "^5.5.0",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
+					}
+				},
+				"path-key": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+					"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+					"dev": true
+				},
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"dev": true
+				},
+				"shebang-command": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+					"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+					"dev": true,
+					"requires": {
+						"shebang-regex": "^1.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+					"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+					"dev": true
+				},
+				"which": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+					"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				}
 			}
 		},
 		"exit": {
@@ -3132,35 +3403,45 @@
 			}
 		},
 		"expect": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-25.2.1.tgz",
-			"integrity": "sha512-mRvuu0xujdgYuS0S2dZ489PGAcXl60blmsLofaq7heqn+ZcUOox+VWQvrCee/x+/0WBpxDs7pBWuFYNO5U+txQ==",
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-26.4.2.tgz",
+			"integrity": "sha512-IlJ3X52Z0lDHm7gjEp+m76uX46ldH5VpqmU0006vqDju/285twh7zaWMRhs67VpQhBwjjMchk+p5aA0VkERCAA==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^25.2.1",
+				"@jest/types": "^26.3.0",
 				"ansi-styles": "^4.0.0",
-				"jest-get-type": "^25.2.1",
-				"jest-matcher-utils": "^25.2.1",
-				"jest-message-util": "^25.2.1",
-				"jest-regex-util": "^25.2.1"
+				"jest-get-type": "^26.3.0",
+				"jest-matcher-utils": "^26.4.2",
+				"jest-message-util": "^26.3.0",
+				"jest-regex-util": "^26.0.0"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-25.2.1.tgz",
-					"integrity": "sha512-WuGFGJ3Rrycg+5ZwQTWKjr21M9psANPAWYD28K42hSeUzhv1H591VXIoq0tjs00mydhNOgVOkKSpzRS3CrOYFw==",
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^1.1.1",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
 						"@types/yargs": "^15.0.0",
-						"chalk": "^3.0.0"
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.4",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-					"integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+					"version": "15.0.7",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
+					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -3177,9 +3458,9 @@
 					}
 				},
 				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
@@ -3202,9 +3483,9 @@
 					"dev": true
 				},
 				"diff-sequences": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.1.tgz",
-					"integrity": "sha512-foe7dXnGlSh3jR1ovJmdv+77VQj98eKCHHwJPbZ2eEf0fHwKbkZicpPxEch9smZ+n2dnF6QFwkOQdLq9hpeJUg==",
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.3.0.tgz",
+					"integrity": "sha512-5j5vdRcw3CNctePNYN0Wy2e/JbWT6cAYnXv5OuqPhDpyCGc0uLu2TK0zOCJWNB9kOIfYMSpIulRaDgIi4HJ6Ig==",
 					"dev": true
 				},
 				"has-flag": {
@@ -3214,42 +3495,42 @@
 					"dev": true
 				},
 				"jest-diff": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.2.1.tgz",
-					"integrity": "sha512-e/TU8VLBBGQQS9tXA5B5LeT806jh7CHUeHbBfrU9UvA2zTbOTRz71UD6fAP1HAhzUEyCVLU2ZP5e8X16A9b0Fg==",
+					"version": "26.4.2",
+					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.4.2.tgz",
+					"integrity": "sha512-6T1XQY8U28WH0Z5rGpQ+VqZSZz8EN8rZcBtfvXaOkbwxIEeRre6qnuZQlbY1AJ4MKDxQF8EkrCvK+hL/VkyYLQ==",
 					"dev": true,
 					"requires": {
-						"chalk": "^3.0.0",
-						"diff-sequences": "^25.2.1",
-						"jest-get-type": "^25.2.1",
-						"pretty-format": "^25.2.1"
+						"chalk": "^4.0.0",
+						"diff-sequences": "^26.3.0",
+						"jest-get-type": "^26.3.0",
+						"pretty-format": "^26.4.2"
 					}
 				},
 				"jest-get-type": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.1.tgz",
-					"integrity": "sha512-EYjTiqcDTCRJDcSNKbLTwn/LcDPEE7ITk8yRMNAOjEsN6yp+Uu+V1gx4djwnuj/DvWg0YGmqaBqPVGsPxlvE7w==",
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+					"integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
 					"dev": true
 				},
 				"jest-matcher-utils": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-25.2.1.tgz",
-					"integrity": "sha512-uuoYY8W6eeVxHUEOvrKIVVTl9X6RP+ohQn2Ta2W8OOLMN6oA8pZUKQEPGxLsSqB3RKfpTueurMLrxDTEZGllsA==",
+					"version": "26.4.2",
+					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.4.2.tgz",
+					"integrity": "sha512-KcbNqWfWUG24R7tu9WcAOKKdiXiXCbMvQYT6iodZ9k1f7065k0keUOW6XpJMMvah+hTfqkhJhRXmA3r3zMAg0Q==",
 					"dev": true,
 					"requires": {
-						"chalk": "^3.0.0",
-						"jest-diff": "^25.2.1",
-						"jest-get-type": "^25.2.1",
-						"pretty-format": "^25.2.1"
+						"chalk": "^4.0.0",
+						"jest-diff": "^26.4.2",
+						"jest-get-type": "^26.3.0",
+						"pretty-format": "^26.4.2"
 					}
 				},
 				"pretty-format": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.2.1.tgz",
-					"integrity": "sha512-YS+e9oGYIbEeAFgqTU8qeZ3DN2Pz0iaD81ox+iUjLIXVJWeB7Ro/2AnfxRnl/yJJ5R674d7E3jLPuh6bwg0+qw==",
+					"version": "26.4.2",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+					"integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^25.2.1",
+						"@jest/types": "^26.3.0",
 						"ansi-regex": "^5.0.0",
 						"ansi-styles": "^4.0.0",
 						"react-is": "^16.12.0"
@@ -3262,9 +3543,9 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -3297,17 +3578,6 @@
 						"is-plain-object": "^2.0.4"
 					}
 				}
-			}
-		},
-		"external-editor": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-			"integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-			"dev": true,
-			"requires": {
-				"chardet": "^0.7.0",
-				"iconv-lite": "^0.4.24",
-				"tmp": "^0.0.33"
 			}
 		},
 		"extglob": {
@@ -3393,6 +3663,20 @@
 			"integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
 			"dev": true
 		},
+		"fast-glob": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
+			"integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+			"dev": true,
+			"requires": {
+				"@nodelib/fs.stat": "^2.0.2",
+				"@nodelib/fs.walk": "^1.2.3",
+				"glob-parent": "^5.1.0",
+				"merge2": "^1.3.0",
+				"micromatch": "^4.0.2",
+				"picomatch": "^2.2.1"
+			}
+		},
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -3405,6 +3689,15 @@
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
 			"dev": true
 		},
+		"fastq": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
+			"integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
+			"dev": true,
+			"requires": {
+				"reusify": "^1.0.4"
+			}
+		},
 		"fb-watchman": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
@@ -3412,15 +3705,6 @@
 			"dev": true,
 			"requires": {
 				"bser": "2.1.1"
-			}
-		},
-		"figures": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-			"integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-			"dev": true,
-			"requires": {
-				"escape-string-regexp": "^1.0.5"
 			}
 		},
 		"file-entry-cache": {
@@ -3433,29 +3717,13 @@
 			}
 		},
 		"file-set": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/file-set/-/file-set-3.0.0.tgz",
-			"integrity": "sha512-B/SdeSIeRv7VlOgIjtH3dkxMI+tEy5m+OeCXfAUsirBoVoY+bGtsmvmmTFPm/G23TBY4RiTtjpcgePCfwXRjqA==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/file-set/-/file-set-4.0.1.tgz",
+			"integrity": "sha512-tRzX4kGPmxS2HDK2q2L4qcPopTl/gcyahve2/O8l8hHNJgJ7m+r/ZncCJ1MmFWEMp1yHxJGIU9gAcsWu5jPMpg==",
 			"dev": true,
 			"requires": {
-				"array-back": "^4.0.0",
-				"glob": "^7.1.5"
-			},
-			"dependencies": {
-				"glob": {
-					"version": "7.1.6",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-					"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-					"dev": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				}
+				"array-back": "^4.0.1",
+				"glob": "^7.1.6"
 			}
 		},
 		"fill-range": {
@@ -3485,21 +3753,12 @@
 			}
 		},
 		"find-up": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 			"dev": true,
 			"requires": {
-				"locate-path": "^5.0.0",
-				"path-exists": "^4.0.0"
-			},
-			"dependencies": {
-				"path-exists": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-					"dev": true
-				}
+				"locate-path": "^2.0.0"
 			}
 		},
 		"flat-cache": {
@@ -3514,9 +3773,9 @@
 			}
 		},
 		"flatted": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
-			"integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+			"integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
 			"dev": true
 		},
 		"for-in": {
@@ -3564,9 +3823,9 @@
 			"dev": true
 		},
 		"fsevents": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-			"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+			"integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
 			"dev": true,
 			"optional": true
 		},
@@ -3592,6 +3851,12 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"dev": true
+		},
+		"get-package-type": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+			"integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
 			"dev": true
 		},
 		"get-stdin": {
@@ -3625,9 +3890,9 @@
 			}
 		},
 		"glob": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-			"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+			"version": "7.1.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
 			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
@@ -3639,24 +3904,49 @@
 			}
 		},
 		"glob-parent": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
-			"integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+			"integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
 			"dev": true,
 			"requires": {
 				"is-glob": "^4.0.1"
 			}
 		},
 		"globals": {
-			"version": "11.12.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-			"dev": true
+			"version": "12.4.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+			"integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+			"dev": true,
+			"requires": {
+				"type-fest": "^0.8.1"
+			}
+		},
+		"globby": {
+			"version": "11.0.1",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
+			"integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
+			"dev": true,
+			"requires": {
+				"array-union": "^2.1.0",
+				"dir-glob": "^3.0.1",
+				"fast-glob": "^3.1.1",
+				"ignore": "^5.1.4",
+				"merge2": "^1.3.0",
+				"slash": "^3.0.0"
+			},
+			"dependencies": {
+				"ignore": {
+					"version": "5.1.8",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+					"integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+					"dev": true
+				}
+			}
 		},
 		"graceful-fs": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
-			"integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
+			"version": "4.2.4",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+			"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
 			"dev": true
 		},
 		"growly": {
@@ -3686,13 +3976,33 @@
 			"dev": true
 		},
 		"har-validator": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-			"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+			"version": "5.1.5",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+			"integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
 			"dev": true,
 			"requires": {
-				"ajv": "^6.5.5",
+				"ajv": "^6.12.3",
 				"har-schema": "^2.0.0"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "6.12.5",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
+					"integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "^3.1.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
+					}
+				},
+				"fast-deep-equal": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+					"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+					"dev": true
+				}
 			}
 		},
 		"has": {
@@ -3711,9 +4021,9 @@
 			"dev": true
 		},
 		"has-symbols": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-			"integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
 			"dev": true
 		},
 		"has-value": {
@@ -3769,24 +4079,24 @@
 			}
 		},
 		"hosted-git-info": {
-			"version": "2.8.5",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
-			"integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
+			"version": "2.8.8",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+			"integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
 			"dev": true
 		},
 		"html-encoding-sniffer": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
-			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
+			"integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
 			"dev": true,
 			"requires": {
-				"whatwg-encoding": "^1.0.1"
+				"whatwg-encoding": "^1.0.5"
 			}
 		},
 		"html-escaper": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.1.tgz",
-			"integrity": "sha512-hNX23TjWwD3q56HpWjUHOKj1+4KKlnjv9PcmBUYKVpga+2cnb9nDx/B1o0yO4n+RZXZdiNxzx6B24C9aNMTkkQ==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
 			"dev": true
 		},
 		"http-signature": {
@@ -3839,6 +4149,66 @@
 			"requires": {
 				"pkg-dir": "^4.2.0",
 				"resolve-cwd": "^3.0.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				},
+				"pkg-dir": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+					"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+					"dev": true,
+					"requires": {
+						"find-up": "^4.0.0"
+					}
+				}
 			}
 		},
 		"imurmurhash": {
@@ -3862,38 +4232,6 @@
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 			"dev": true
-		},
-		"inquirer": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.4.tgz",
-			"integrity": "sha512-Bu5Td5+j11sCkqfqmUTiwv+tWisMtP0L7Q8WrqA2C/BbBhy1YTdFrvjjlrKq8oagA/tLQBski2Gcx/Sqyi2qSQ==",
-			"dev": true,
-			"requires": {
-				"ansi-escapes": "^4.2.1",
-				"chalk": "^2.4.2",
-				"cli-cursor": "^3.1.0",
-				"cli-width": "^2.0.0",
-				"external-editor": "^3.0.3",
-				"figures": "^3.0.0",
-				"lodash": "^4.17.15",
-				"mute-stream": "0.0.8",
-				"run-async": "^2.2.0",
-				"rxjs": "^6.5.3",
-				"string-width": "^4.1.0",
-				"strip-ansi": "^5.1.0",
-				"through": "^2.3.6"
-			},
-			"dependencies": {
-				"ansi-escapes": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.0.tgz",
-					"integrity": "sha512-EiYhwo0v255HUL6eDyuLrXEkTi7WwVCLAw+SeOQ7M7qdun1z1pum4DEm/nuqIVbPvi9RPPc9k9LbyBv6H0DwVg==",
-					"dev": true,
-					"requires": {
-						"type-fest": "^0.8.1"
-					}
-				}
-			}
 		},
 		"ip-regex": {
 			"version": "2.1.0",
@@ -3934,9 +4272,9 @@
 			"dev": true
 		},
 		"is-callable": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-			"integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+			"integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
 			"dev": true
 		},
 		"is-ci": {
@@ -3969,9 +4307,9 @@
 			}
 		},
 		"is-date-object": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+			"integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
 			"dev": true
 		},
 		"is-descriptor": {
@@ -3992,6 +4330,13 @@
 					"dev": true
 				}
 			}
+		},
+		"is-docker": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz",
+			"integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==",
+			"dev": true,
+			"optional": true
 		},
 		"is-extendable": {
 			"version": "0.1.1",
@@ -4026,6 +4371,12 @@
 				"is-extglob": "^2.1.1"
 			}
 		},
+		"is-negative-zero": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.0.tgz",
+			"integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=",
+			"dev": true
+		},
 		"is-number": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -4041,19 +4392,19 @@
 				"isobject": "^3.0.1"
 			}
 		},
-		"is-promise": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+		"is-potential-custom-element-name": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz",
+			"integrity": "sha1-DFLlS8yjkbssSUsh6GJtczbG45c=",
 			"dev": true
 		},
 		"is-regex": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
-			"integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+			"integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
 			"dev": true,
 			"requires": {
-				"has": "^1.0.3"
+				"has-symbols": "^1.0.1"
 			}
 		},
 		"is-stream": {
@@ -4069,12 +4420,12 @@
 			"dev": true
 		},
 		"is-symbol": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
-			"integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+			"integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
 			"dev": true,
 			"requires": {
-				"has-symbols": "^1.0.0"
+				"has-symbols": "^1.0.1"
 			}
 		},
 		"is-typedarray": {
@@ -4090,11 +4441,14 @@
 			"dev": true
 		},
 		"is-wsl": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.1.1.tgz",
-			"integrity": "sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+			"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"requires": {
+				"is-docker": "^2.0.0"
+			}
 		},
 		"isarray": {
 			"version": "1.0.0",
@@ -4127,18 +4481,23 @@
 			"dev": true
 		},
 		"istanbul-lib-instrument": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.1.tgz",
-			"integrity": "sha512-imIchxnodll7pvQBYOqUu88EufLCU56LMeFPZZM/fJZ1irYcYdqroaV+ACK1Ila8ls09iEYArp+nqyC6lW1Vfg==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+			"integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.7.5",
-				"@babel/parser": "^7.7.5",
-				"@babel/template": "^7.7.4",
-				"@babel/traverse": "^7.7.4",
 				"@istanbuljs/schema": "^0.1.2",
 				"istanbul-lib-coverage": "^3.0.0",
 				"semver": "^6.3.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
 			}
 		},
 		"istanbul-lib-report": {
@@ -4159,9 +4518,9 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -4181,9 +4540,9 @@
 			}
 		},
 		"istanbul-reports": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.1.tgz",
-			"integrity": "sha512-Vm9xwCiQ8t2cNNnckyeAV0UdxKpcQUz4nMxsBvIu8n2kmPSiyb5uaF/8LpmKr+yqL/MdOXaX2Nmdo4Qyxium9Q==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
+			"integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
 			"dev": true,
 			"requires": {
 				"html-escaper": "^2.0.0",
@@ -4191,32 +4550,42 @@
 			}
 		},
 		"jest": {
-			"version": "25.2.2",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-25.2.2.tgz",
-			"integrity": "sha512-ap4gCAuRGuE2gBh2AD18zFpcHzqkAWHDU12sk66GjYxKJDXn11Djgh9dCE4HXJbtQ+C6Gurc+EcqOWO9YcPbzA==",
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-26.4.2.tgz",
+			"integrity": "sha512-LLCjPrUh98Ik8CzW8LLVnSCfLaiY+wbK53U7VxnFSX7Q+kWC4noVeDvGWIFw0Amfq1lq2VfGm7YHWSLBV62MJw==",
 			"dev": true,
 			"requires": {
-				"@jest/core": "^25.2.2",
+				"@jest/core": "^26.4.2",
 				"import-local": "^3.0.2",
-				"jest-cli": "^25.2.2"
+				"jest-cli": "^26.4.2"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-25.2.1.tgz",
-					"integrity": "sha512-WuGFGJ3Rrycg+5ZwQTWKjr21M9psANPAWYD28K42hSeUzhv1H591VXIoq0tjs00mydhNOgVOkKSpzRS3CrOYFw==",
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^1.1.1",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
 						"@types/yargs": "^15.0.0",
-						"chalk": "^3.0.0"
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.4",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-					"integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+					"version": "15.0.7",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
+					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -4233,9 +4602,9 @@
 					}
 				},
 				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
@@ -4264,30 +4633,30 @@
 					"dev": true
 				},
 				"jest-cli": {
-					"version": "25.2.2",
-					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-25.2.2.tgz",
-					"integrity": "sha512-glCp46vt4J72LSOvLAav2nBfuLFoqWqniguF7Q5IOXNu3jMo1BIZwm3gyP2mEJx9ZlxUKEZhc3r3E4SRDMAQ/A==",
+					"version": "26.4.2",
+					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.4.2.tgz",
+					"integrity": "sha512-zb+lGd/SfrPvoRSC/0LWdaWCnscXc1mGYW//NP4/tmBvRPT3VntZ2jtKUONsRi59zc5JqmsSajA9ewJKFYp8Cw==",
 					"dev": true,
 					"requires": {
-						"@jest/core": "^25.2.2",
-						"@jest/test-result": "^25.2.1",
-						"@jest/types": "^25.2.1",
-						"chalk": "^3.0.0",
+						"@jest/core": "^26.4.2",
+						"@jest/test-result": "^26.3.0",
+						"@jest/types": "^26.3.0",
+						"chalk": "^4.0.0",
 						"exit": "^0.1.2",
+						"graceful-fs": "^4.2.4",
 						"import-local": "^3.0.2",
 						"is-ci": "^2.0.0",
-						"jest-config": "^25.2.2",
-						"jest-util": "^25.2.1",
-						"jest-validate": "^25.2.1",
+						"jest-config": "^26.4.2",
+						"jest-util": "^26.3.0",
+						"jest-validate": "^26.4.2",
 						"prompts": "^2.0.1",
-						"realpath-native": "^2.0.0",
 						"yargs": "^15.3.1"
 					}
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -4296,32 +4665,42 @@
 			}
 		},
 		"jest-changed-files": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-25.2.1.tgz",
-			"integrity": "sha512-BB4XjM/dJNUAUtchZ2yJq50VK8XXbmgvt1MUD6kzgzoyz9F0+1ZDQ1yNvLl6pfDwKrMBG9GBY1lzaIBO3JByMg==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.3.0.tgz",
+			"integrity": "sha512-1C4R4nijgPltX6fugKxM4oQ18zimS7LqQ+zTTY8lMCMFPrxqBFb7KJH0Z2fRQJvw2Slbaipsqq7s1mgX5Iot+g==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^25.2.1",
-				"execa": "^3.2.0",
+				"@jest/types": "^26.3.0",
+				"execa": "^4.0.0",
 				"throat": "^5.0.0"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-25.2.1.tgz",
-					"integrity": "sha512-WuGFGJ3Rrycg+5ZwQTWKjr21M9psANPAWYD28K42hSeUzhv1H591VXIoq0tjs00mydhNOgVOkKSpzRS3CrOYFw==",
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^1.1.1",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
 						"@types/yargs": "^15.0.0",
-						"chalk": "^3.0.0"
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.4",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-					"integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+					"version": "15.0.7",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
+					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -4338,9 +4717,9 @@
 					}
 				},
 				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
@@ -4362,21 +4741,10 @@
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 					"dev": true
 				},
-				"cross-spawn": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
-					"integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
-					"dev": true,
-					"requires": {
-						"path-key": "^3.1.0",
-						"shebang-command": "^2.0.0",
-						"which": "^2.0.1"
-					}
-				},
 				"execa": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
-					"integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
+					"integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
 					"dev": true,
 					"requires": {
 						"cross-spawn": "^7.0.0",
@@ -4386,15 +4754,14 @@
 						"merge-stream": "^2.0.0",
 						"npm-run-path": "^4.0.0",
 						"onetime": "^5.1.0",
-						"p-finally": "^2.0.0",
 						"signal-exit": "^3.0.2",
 						"strip-final-newline": "^2.0.0"
 					}
 				},
 				"get-stream": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-					"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
 					"dev": true,
 					"requires": {
 						"pump": "^3.0.0"
@@ -4421,95 +4788,69 @@
 						"path-key": "^3.0.0"
 					}
 				},
-				"p-finally": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
-					"integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
-					"dev": true
-				},
-				"path-key": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-					"dev": true
-				},
-				"shebang-command": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-					"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-					"dev": true,
-					"requires": {
-						"shebang-regex": "^3.0.0"
-					}
-				},
-				"shebang-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-					"dev": true
-				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
-					}
-				},
-				"which": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-					"dev": true,
-					"requires": {
-						"isexe": "^2.0.0"
 					}
 				}
 			}
 		},
 		"jest-config": {
-			"version": "25.2.2",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-25.2.2.tgz",
-			"integrity": "sha512-nnFcjd57kyc9q5vS1DRQQqowxKiRO6jmonL/lo84DL8Zjdng97jaty6EzJ37lMOqvehZY1ovqKgC7Ki0Iqa/wA==",
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.4.2.tgz",
+			"integrity": "sha512-QBf7YGLuToiM8PmTnJEdRxyYy3mHWLh24LJZKVdXZ2PNdizSe1B/E8bVm+HYcjbEzGuVXDv/di+EzdO/6Gq80A==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.1.0",
-				"@jest/test-sequencer": "^25.2.2",
-				"@jest/types": "^25.2.1",
-				"babel-jest": "^25.2.1",
-				"chalk": "^3.0.0",
+				"@jest/test-sequencer": "^26.4.2",
+				"@jest/types": "^26.3.0",
+				"babel-jest": "^26.3.0",
+				"chalk": "^4.0.0",
 				"deepmerge": "^4.2.2",
 				"glob": "^7.1.1",
-				"jest-environment-jsdom": "^25.2.1",
-				"jest-environment-node": "^25.2.2",
-				"jest-get-type": "^25.2.1",
-				"jest-jasmine2": "^25.2.2",
-				"jest-regex-util": "^25.2.1",
-				"jest-resolve": "^25.2.1",
-				"jest-util": "^25.2.1",
-				"jest-validate": "^25.2.1",
+				"graceful-fs": "^4.2.4",
+				"jest-environment-jsdom": "^26.3.0",
+				"jest-environment-node": "^26.3.0",
+				"jest-get-type": "^26.3.0",
+				"jest-jasmine2": "^26.4.2",
+				"jest-regex-util": "^26.0.0",
+				"jest-resolve": "^26.4.0",
+				"jest-util": "^26.3.0",
+				"jest-validate": "^26.4.2",
 				"micromatch": "^4.0.2",
-				"pretty-format": "^25.2.1",
-				"realpath-native": "^2.0.0"
+				"pretty-format": "^26.4.2"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-25.2.1.tgz",
-					"integrity": "sha512-WuGFGJ3Rrycg+5ZwQTWKjr21M9psANPAWYD28K42hSeUzhv1H591VXIoq0tjs00mydhNOgVOkKSpzRS3CrOYFw==",
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^1.1.1",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
 						"@types/yargs": "^15.0.0",
-						"chalk": "^3.0.0"
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.4",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-					"integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+					"version": "15.0.7",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
+					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -4526,9 +4867,9 @@
 					}
 				},
 				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
@@ -4557,18 +4898,18 @@
 					"dev": true
 				},
 				"jest-get-type": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.1.tgz",
-					"integrity": "sha512-EYjTiqcDTCRJDcSNKbLTwn/LcDPEE7ITk8yRMNAOjEsN6yp+Uu+V1gx4djwnuj/DvWg0YGmqaBqPVGsPxlvE7w==",
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+					"integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
 					"dev": true
 				},
 				"pretty-format": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.2.1.tgz",
-					"integrity": "sha512-YS+e9oGYIbEeAFgqTU8qeZ3DN2Pz0iaD81ox+iUjLIXVJWeB7Ro/2AnfxRnl/yJJ5R674d7E3jLPuh6bwg0+qw==",
+					"version": "26.4.2",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+					"integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^25.2.1",
+						"@jest/types": "^26.3.0",
 						"ansi-regex": "^5.0.0",
 						"ansi-styles": "^4.0.0",
 						"react-is": "^16.12.0"
@@ -4581,9 +4922,9 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -4604,43 +4945,53 @@
 			}
 		},
 		"jest-docblock": {
-			"version": "25.2.0",
-			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-25.2.0.tgz",
-			"integrity": "sha512-M7ZDbghaxFd2unWkyDFGLZDjPpIbDtEbICXSzwGrUBccFwVG/1dhLLAYX3D+98bFksaJuM0iMZGuIQUzKgnkQw==",
+			"version": "26.0.0",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-26.0.0.tgz",
+			"integrity": "sha512-RDZ4Iz3QbtRWycd8bUEPxQsTlYazfYn/h5R65Fc6gOfwozFhoImx+affzky/FFBuqISPTqjXomoIGJVKBWoo0w==",
 			"dev": true,
 			"requires": {
 				"detect-newline": "^3.0.0"
 			}
 		},
 		"jest-each": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-25.2.1.tgz",
-			"integrity": "sha512-2vWAaf11IJsSwkEzGph3un4OMSG4v/3hpM2UqJdeU3peGUgUSn75TlXZGQnT0smbnAr4eE+URW1OpE8U9wl0TA==",
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.4.2.tgz",
+			"integrity": "sha512-p15rt8r8cUcRY0Mvo1fpkOGYm7iI8S6ySxgIdfh3oOIv+gHwrHTy5VWCGOecWUhDsit4Nz8avJWdT07WLpbwDA==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^25.2.1",
-				"chalk": "^3.0.0",
-				"jest-get-type": "^25.2.1",
-				"jest-util": "^25.2.1",
-				"pretty-format": "^25.2.1"
+				"@jest/types": "^26.3.0",
+				"chalk": "^4.0.0",
+				"jest-get-type": "^26.3.0",
+				"jest-util": "^26.3.0",
+				"pretty-format": "^26.4.2"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-25.2.1.tgz",
-					"integrity": "sha512-WuGFGJ3Rrycg+5ZwQTWKjr21M9psANPAWYD28K42hSeUzhv1H591VXIoq0tjs00mydhNOgVOkKSpzRS3CrOYFw==",
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^1.1.1",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
 						"@types/yargs": "^15.0.0",
-						"chalk": "^3.0.0"
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.4",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-					"integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+					"version": "15.0.7",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
+					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -4657,9 +5008,9 @@
 					}
 				},
 				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
@@ -4688,18 +5039,18 @@
 					"dev": true
 				},
 				"jest-get-type": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.1.tgz",
-					"integrity": "sha512-EYjTiqcDTCRJDcSNKbLTwn/LcDPEE7ITk8yRMNAOjEsN6yp+Uu+V1gx4djwnuj/DvWg0YGmqaBqPVGsPxlvE7w==",
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+					"integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
 					"dev": true
 				},
 				"pretty-format": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.2.1.tgz",
-					"integrity": "sha512-YS+e9oGYIbEeAFgqTU8qeZ3DN2Pz0iaD81ox+iUjLIXVJWeB7Ro/2AnfxRnl/yJJ5R674d7E3jLPuh6bwg0+qw==",
+					"version": "26.4.2",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+					"integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^25.2.1",
+						"@jest/types": "^26.3.0",
 						"ansi-regex": "^5.0.0",
 						"ansi-styles": "^4.0.0",
 						"react-is": "^16.12.0"
@@ -4712,9 +5063,9 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -4723,35 +5074,46 @@
 			}
 		},
 		"jest-environment-jsdom": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-25.2.1.tgz",
-			"integrity": "sha512-bUhhhXtgrOgLhsFQFXgao8CQPYAEwtaVvhsF6O0A7Ie2uPONtAKCwuxyOM9WJaz9ag2ci5Pg7i2V2PRfGLl95w==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.3.0.tgz",
+			"integrity": "sha512-zra8He2btIMJkAzvLaiZ9QwEPGEetbxqmjEBQwhH3CA+Hhhu0jSiEJxnJMbX28TGUvPLxBt/zyaTLrOPF4yMJA==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^25.2.1",
-				"@jest/fake-timers": "^25.2.1",
-				"@jest/types": "^25.2.1",
-				"jest-mock": "^25.2.1",
-				"jest-util": "^25.2.1",
-				"jsdom": "^15.2.1"
+				"@jest/environment": "^26.3.0",
+				"@jest/fake-timers": "^26.3.0",
+				"@jest/types": "^26.3.0",
+				"@types/node": "*",
+				"jest-mock": "^26.3.0",
+				"jest-util": "^26.3.0",
+				"jsdom": "^16.2.2"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-25.2.1.tgz",
-					"integrity": "sha512-WuGFGJ3Rrycg+5ZwQTWKjr21M9psANPAWYD28K42hSeUzhv1H591VXIoq0tjs00mydhNOgVOkKSpzRS3CrOYFw==",
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^1.1.1",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
 						"@types/yargs": "^15.0.0",
-						"chalk": "^3.0.0"
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.4",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-					"integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+					"version": "15.0.7",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
+					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -4768,9 +5130,9 @@
 					}
 				},
 				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
@@ -4799,9 +5161,9 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -4810,35 +5172,45 @@
 			}
 		},
 		"jest-environment-node": {
-			"version": "25.2.2",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-25.2.2.tgz",
-			"integrity": "sha512-3V1zivv0EAu4xoeLaQVHjDrniAB4JU9iOUqpsUpJjL5P8zFuSxpGL9K0zBdnaZFVfQCWSa2pLbSfpWItcLPijQ==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.3.0.tgz",
+			"integrity": "sha512-c9BvYoo+FGcMj5FunbBgtBnbR5qk3uky8PKyRVpSfe2/8+LrNQMiXX53z6q2kY+j15SkjQCOSL/6LHnCPLVHNw==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^25.2.1",
-				"@jest/fake-timers": "^25.2.1",
-				"@jest/types": "^25.2.1",
-				"jest-mock": "^25.2.1",
-				"jest-util": "^25.2.1",
-				"semver": "^6.3.0"
+				"@jest/environment": "^26.3.0",
+				"@jest/fake-timers": "^26.3.0",
+				"@jest/types": "^26.3.0",
+				"@types/node": "*",
+				"jest-mock": "^26.3.0",
+				"jest-util": "^26.3.0"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-25.2.1.tgz",
-					"integrity": "sha512-WuGFGJ3Rrycg+5ZwQTWKjr21M9psANPAWYD28K42hSeUzhv1H591VXIoq0tjs00mydhNOgVOkKSpzRS3CrOYFw==",
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^1.1.1",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
 						"@types/yargs": "^15.0.0",
-						"chalk": "^3.0.0"
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.4",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-					"integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+					"version": "15.0.7",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
+					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -4855,9 +5227,9 @@
 					}
 				},
 				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
@@ -4886,9 +5258,9 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -4903,41 +5275,53 @@
 			"dev": true
 		},
 		"jest-haste-map": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-25.2.1.tgz",
-			"integrity": "sha512-svz3KbQmv9qeomR0LlRjQfoi7lQbZQkC39m7uHFKhqyEuX4F6DH6HayNPSEbTCZDx6d9/ljxfAcxlPpgQvrpvQ==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.3.0.tgz",
+			"integrity": "sha512-DHWBpTJgJhLLGwE5Z1ZaqLTYqeODQIZpby0zMBsCU9iRFHYyhklYqP4EiG73j5dkbaAdSZhgB938mL51Q5LeZA==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^25.2.1",
+				"@jest/types": "^26.3.0",
+				"@types/graceful-fs": "^4.1.2",
+				"@types/node": "*",
 				"anymatch": "^3.0.3",
 				"fb-watchman": "^2.0.0",
 				"fsevents": "^2.1.2",
-				"graceful-fs": "^4.2.3",
-				"jest-serializer": "^25.2.1",
-				"jest-util": "^25.2.1",
-				"jest-worker": "^25.2.1",
+				"graceful-fs": "^4.2.4",
+				"jest-regex-util": "^26.0.0",
+				"jest-serializer": "^26.3.0",
+				"jest-util": "^26.3.0",
+				"jest-worker": "^26.3.0",
 				"micromatch": "^4.0.2",
 				"sane": "^4.0.3",
-				"walker": "^1.0.7",
-				"which": "^2.0.2"
+				"walker": "^1.0.7"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-25.2.1.tgz",
-					"integrity": "sha512-WuGFGJ3Rrycg+5ZwQTWKjr21M9psANPAWYD28K42hSeUzhv1H591VXIoq0tjs00mydhNOgVOkKSpzRS3CrOYFw==",
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^1.1.1",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
 						"@types/yargs": "^15.0.0",
-						"chalk": "^3.0.0"
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.4",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-					"integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+					"version": "15.0.7",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
+					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -4954,9 +5338,9 @@
 					}
 				},
 				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
@@ -4978,12 +5362,6 @@
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 					"dev": true
 				},
-				"graceful-fs": {
-					"version": "4.2.3",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-					"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
-					"dev": true
-				},
 				"has-flag": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -4991,66 +5369,68 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
-					}
-				},
-				"which": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-					"dev": true,
-					"requires": {
-						"isexe": "^2.0.0"
 					}
 				}
 			}
 		},
 		"jest-jasmine2": {
-			"version": "25.2.2",
-			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-25.2.2.tgz",
-			"integrity": "sha512-lB/32iLzuupTlKUlZz1QxKILkMbAIL4iq4O0wjMH6FPBKnkf8YgdQchDQyIzK98xrdYF+DdvmsaS/m6bt+jSiA==",
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.4.2.tgz",
+			"integrity": "sha512-z7H4EpCldHN1J8fNgsja58QftxBSL+JcwZmaXIvV9WKIM+x49F4GLHu/+BQh2kzRKHAgaN/E82od+8rTOBPyPA==",
 			"dev": true,
 			"requires": {
 				"@babel/traverse": "^7.1.0",
-				"@jest/environment": "^25.2.1",
-				"@jest/source-map": "^25.2.1",
-				"@jest/test-result": "^25.2.1",
-				"@jest/types": "^25.2.1",
-				"chalk": "^3.0.0",
+				"@jest/environment": "^26.3.0",
+				"@jest/source-map": "^26.3.0",
+				"@jest/test-result": "^26.3.0",
+				"@jest/types": "^26.3.0",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
 				"co": "^4.6.0",
-				"expect": "^25.2.1",
+				"expect": "^26.4.2",
 				"is-generator-fn": "^2.0.0",
-				"jest-each": "^25.2.1",
-				"jest-matcher-utils": "^25.2.1",
-				"jest-message-util": "^25.2.1",
-				"jest-runtime": "^25.2.2",
-				"jest-snapshot": "^25.2.1",
-				"jest-util": "^25.2.1",
-				"pretty-format": "^25.2.1",
+				"jest-each": "^26.4.2",
+				"jest-matcher-utils": "^26.4.2",
+				"jest-message-util": "^26.3.0",
+				"jest-runtime": "^26.4.2",
+				"jest-snapshot": "^26.4.2",
+				"jest-util": "^26.3.0",
+				"pretty-format": "^26.4.2",
 				"throat": "^5.0.0"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-25.2.1.tgz",
-					"integrity": "sha512-WuGFGJ3Rrycg+5ZwQTWKjr21M9psANPAWYD28K42hSeUzhv1H591VXIoq0tjs00mydhNOgVOkKSpzRS3CrOYFw==",
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^1.1.1",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
 						"@types/yargs": "^15.0.0",
-						"chalk": "^3.0.0"
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.4",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-					"integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+					"version": "15.0.7",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
+					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -5067,9 +5447,9 @@
 					}
 				},
 				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
@@ -5092,9 +5472,9 @@
 					"dev": true
 				},
 				"diff-sequences": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.1.tgz",
-					"integrity": "sha512-foe7dXnGlSh3jR1ovJmdv+77VQj98eKCHHwJPbZ2eEf0fHwKbkZicpPxEch9smZ+n2dnF6QFwkOQdLq9hpeJUg==",
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.3.0.tgz",
+					"integrity": "sha512-5j5vdRcw3CNctePNYN0Wy2e/JbWT6cAYnXv5OuqPhDpyCGc0uLu2TK0zOCJWNB9kOIfYMSpIulRaDgIi4HJ6Ig==",
 					"dev": true
 				},
 				"has-flag": {
@@ -5104,42 +5484,42 @@
 					"dev": true
 				},
 				"jest-diff": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.2.1.tgz",
-					"integrity": "sha512-e/TU8VLBBGQQS9tXA5B5LeT806jh7CHUeHbBfrU9UvA2zTbOTRz71UD6fAP1HAhzUEyCVLU2ZP5e8X16A9b0Fg==",
+					"version": "26.4.2",
+					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.4.2.tgz",
+					"integrity": "sha512-6T1XQY8U28WH0Z5rGpQ+VqZSZz8EN8rZcBtfvXaOkbwxIEeRre6qnuZQlbY1AJ4MKDxQF8EkrCvK+hL/VkyYLQ==",
 					"dev": true,
 					"requires": {
-						"chalk": "^3.0.0",
-						"diff-sequences": "^25.2.1",
-						"jest-get-type": "^25.2.1",
-						"pretty-format": "^25.2.1"
+						"chalk": "^4.0.0",
+						"diff-sequences": "^26.3.0",
+						"jest-get-type": "^26.3.0",
+						"pretty-format": "^26.4.2"
 					}
 				},
 				"jest-get-type": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.1.tgz",
-					"integrity": "sha512-EYjTiqcDTCRJDcSNKbLTwn/LcDPEE7ITk8yRMNAOjEsN6yp+Uu+V1gx4djwnuj/DvWg0YGmqaBqPVGsPxlvE7w==",
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+					"integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
 					"dev": true
 				},
 				"jest-matcher-utils": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-25.2.1.tgz",
-					"integrity": "sha512-uuoYY8W6eeVxHUEOvrKIVVTl9X6RP+ohQn2Ta2W8OOLMN6oA8pZUKQEPGxLsSqB3RKfpTueurMLrxDTEZGllsA==",
+					"version": "26.4.2",
+					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.4.2.tgz",
+					"integrity": "sha512-KcbNqWfWUG24R7tu9WcAOKKdiXiXCbMvQYT6iodZ9k1f7065k0keUOW6XpJMMvah+hTfqkhJhRXmA3r3zMAg0Q==",
 					"dev": true,
 					"requires": {
-						"chalk": "^3.0.0",
-						"jest-diff": "^25.2.1",
-						"jest-get-type": "^25.2.1",
-						"pretty-format": "^25.2.1"
+						"chalk": "^4.0.0",
+						"jest-diff": "^26.4.2",
+						"jest-get-type": "^26.3.0",
+						"pretty-format": "^26.4.2"
 					}
 				},
 				"pretty-format": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.2.1.tgz",
-					"integrity": "sha512-YS+e9oGYIbEeAFgqTU8qeZ3DN2Pz0iaD81ox+iUjLIXVJWeB7Ro/2AnfxRnl/yJJ5R674d7E3jLPuh6bwg0+qw==",
+					"version": "26.4.2",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+					"integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^25.2.1",
+						"@jest/types": "^26.3.0",
 						"ansi-regex": "^5.0.0",
 						"ansi-styles": "^4.0.0",
 						"react-is": "^16.12.0"
@@ -5152,9 +5532,9 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -5174,31 +5554,41 @@
 			}
 		},
 		"jest-leak-detector": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-25.2.1.tgz",
-			"integrity": "sha512-bsxjjFksjLWNqC8aLsN0KO2KQ3tiqPqmFpYt+0y4RLHc1dqaThQL68jra5y1f/yhX3dNC8ugksDvqnGxwxjo4w==",
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.4.2.tgz",
+			"integrity": "sha512-akzGcxwxtE+9ZJZRW+M2o+nTNnmQZxrHJxX/HjgDaU5+PLmY1qnQPnMjgADPGCRPhB+Yawe1iij0REe+k/aHoA==",
 			"dev": true,
 			"requires": {
-				"jest-get-type": "^25.2.1",
-				"pretty-format": "^25.2.1"
+				"jest-get-type": "^26.3.0",
+				"pretty-format": "^26.4.2"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-25.2.1.tgz",
-					"integrity": "sha512-WuGFGJ3Rrycg+5ZwQTWKjr21M9psANPAWYD28K42hSeUzhv1H591VXIoq0tjs00mydhNOgVOkKSpzRS3CrOYFw==",
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^1.1.1",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
 						"@types/yargs": "^15.0.0",
-						"chalk": "^3.0.0"
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.4",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-					"integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+					"version": "15.0.7",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
+					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -5215,9 +5605,9 @@
 					}
 				},
 				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
@@ -5246,18 +5636,18 @@
 					"dev": true
 				},
 				"jest-get-type": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.1.tgz",
-					"integrity": "sha512-EYjTiqcDTCRJDcSNKbLTwn/LcDPEE7ITk8yRMNAOjEsN6yp+Uu+V1gx4djwnuj/DvWg0YGmqaBqPVGsPxlvE7w==",
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+					"integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
 					"dev": true
 				},
 				"pretty-format": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.2.1.tgz",
-					"integrity": "sha512-YS+e9oGYIbEeAFgqTU8qeZ3DN2Pz0iaD81ox+iUjLIXVJWeB7Ro/2AnfxRnl/yJJ5R674d7E3jLPuh6bwg0+qw==",
+					"version": "26.4.2",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+					"integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^25.2.1",
+						"@jest/types": "^26.3.0",
 						"ansi-regex": "^5.0.0",
 						"ansi-styles": "^4.0.0",
 						"react-is": "^16.12.0"
@@ -5270,9 +5660,9 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -5293,37 +5683,47 @@
 			}
 		},
 		"jest-message-util": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-25.2.1.tgz",
-			"integrity": "sha512-pxwehr9uPEuCI9bPjBiZxpFMN0+3wny5p7/E3hbV9XjsqREhJJAMf0czvHtgNeUBo2iAiAI9yi9ICKHPOKePEw==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.3.0.tgz",
+			"integrity": "sha512-xIavRYqr4/otGOiLxLZGj3ieMmjcNE73Ui+LdSW/Y790j5acqCsAdDiLIbzHCZMpN07JOENRWX5DcU+OQ+TjTA==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@jest/test-result": "^25.2.1",
-				"@jest/types": "^25.2.1",
+				"@jest/types": "^26.3.0",
 				"@types/stack-utils": "^1.0.1",
-				"chalk": "^3.0.0",
+				"chalk": "^4.0.0",
+				"graceful-fs": "^4.2.4",
 				"micromatch": "^4.0.2",
 				"slash": "^3.0.0",
-				"stack-utils": "^1.0.1"
+				"stack-utils": "^2.0.2"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-25.2.1.tgz",
-					"integrity": "sha512-WuGFGJ3Rrycg+5ZwQTWKjr21M9psANPAWYD28K42hSeUzhv1H591VXIoq0tjs00mydhNOgVOkKSpzRS3CrOYFw==",
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^1.1.1",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
 						"@types/yargs": "^15.0.0",
-						"chalk": "^3.0.0"
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.4",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-					"integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+					"version": "15.0.7",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
+					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -5340,9 +5740,9 @@
 					}
 				},
 				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
@@ -5371,9 +5771,9 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -5382,30 +5782,41 @@
 			}
 		},
 		"jest-mock": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-25.2.1.tgz",
-			"integrity": "sha512-ZXcmqpCTG1MEm2AP2q9XiJzdbQ655Pnssj+xQMP1thrW2ptEFrd4vSkxTpxk6rnluLPRKagaHmzUpWNxShMvqQ==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.3.0.tgz",
+			"integrity": "sha512-PeaRrg8Dc6mnS35gOo/CbZovoDPKAeB1FICZiuagAgGvbWdNNyjQjkOaGUa/3N3JtpQ/Mh9P4A2D4Fv51NnP8Q==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^25.2.1"
+				"@jest/types": "^26.3.0",
+				"@types/node": "*"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-25.2.1.tgz",
-					"integrity": "sha512-WuGFGJ3Rrycg+5ZwQTWKjr21M9psANPAWYD28K42hSeUzhv1H591VXIoq0tjs00mydhNOgVOkKSpzRS3CrOYFw==",
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^1.1.1",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
 						"@types/yargs": "^15.0.0",
-						"chalk": "^3.0.0"
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.4",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-					"integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+					"version": "15.0.7",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
+					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -5422,9 +5833,9 @@
 					}
 				},
 				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
@@ -5453,9 +5864,9 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -5464,47 +5875,59 @@
 			}
 		},
 		"jest-pnp-resolver": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
-			"integrity": "sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
+			"integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
 			"dev": true
 		},
 		"jest-regex-util": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-25.2.1.tgz",
-			"integrity": "sha512-wroFVJw62LdqTdkL508ZLV82FrJJWVJMIuYG7q4Uunl1WAPTf4ftPKrqqfec4SvOIlvRZUdEX2TFpWR356YG/w==",
+			"version": "26.0.0",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-26.0.0.tgz",
+			"integrity": "sha512-Gv3ZIs/nA48/Zvjrl34bf+oD76JHiGDUxNOVgUjh3j890sblXryjY4rss71fPtD/njchl6PSE2hIhvyWa1eT0A==",
 			"dev": true
 		},
 		"jest-resolve": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-25.2.1.tgz",
-			"integrity": "sha512-5rVc6khEckNH62adcR+jlYd34/jBO/U22VHf+elmyO6UBHNWXSbfy63+spJRN4GQ/0dbu6Hi6ZVdR58bmNG2Eg==",
+			"version": "26.4.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.4.0.tgz",
+			"integrity": "sha512-bn/JoZTEXRSlEx3+SfgZcJAVuTMOksYq9xe9O6s4Ekg84aKBObEaVXKOEilULRqviSLAYJldnoWV9c07kwtiCg==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^25.2.1",
-				"browser-resolve": "^1.11.3",
-				"chalk": "^3.0.0",
-				"jest-pnp-resolver": "^1.2.1",
-				"realpath-native": "^2.0.0",
-				"resolve": "^1.15.1"
+				"@jest/types": "^26.3.0",
+				"chalk": "^4.0.0",
+				"graceful-fs": "^4.2.4",
+				"jest-pnp-resolver": "^1.2.2",
+				"jest-util": "^26.3.0",
+				"read-pkg-up": "^7.0.1",
+				"resolve": "^1.17.0",
+				"slash": "^3.0.0"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-25.2.1.tgz",
-					"integrity": "sha512-WuGFGJ3Rrycg+5ZwQTWKjr21M9psANPAWYD28K42hSeUzhv1H591VXIoq0tjs00mydhNOgVOkKSpzRS3CrOYFw==",
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^1.1.1",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
 						"@types/yargs": "^15.0.0",
-						"chalk": "^3.0.0"
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.4",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-					"integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+					"version": "15.0.7",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
+					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -5521,9 +5944,9 @@
 					}
 				},
 				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
@@ -5545,25 +5968,108 @@
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 					"dev": true
 				},
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
 				"has-flag": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 					"dev": true
 				},
-				"resolve": {
-					"version": "1.15.1",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
-					"integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
 					"dev": true,
 					"requires": {
-						"path-parse": "^1.0.6"
+						"p-locate": "^4.1.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
+				},
+				"parse-json": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
+					"integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"error-ex": "^1.3.1",
+						"json-parse-even-better-errors": "^2.3.0",
+						"lines-and-columns": "^1.1.6"
+					}
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				},
+				"read-pkg": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+					"integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+					"dev": true,
+					"requires": {
+						"@types/normalize-package-data": "^2.4.0",
+						"normalize-package-data": "^2.5.0",
+						"parse-json": "^5.0.0",
+						"type-fest": "^0.6.0"
+					},
+					"dependencies": {
+						"type-fest": {
+							"version": "0.6.0",
+							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+							"integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+							"dev": true
+						}
+					}
+				},
+				"read-pkg-up": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+					"integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+					"dev": true,
+					"requires": {
+						"find-up": "^4.1.0",
+						"read-pkg": "^5.2.0",
+						"type-fest": "^0.8.1"
 					}
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -5572,32 +6078,42 @@
 			}
 		},
 		"jest-resolve-dependencies": {
-			"version": "25.2.2",
-			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-25.2.2.tgz",
-			"integrity": "sha512-XeBlobvYexxYOUC6PAuISJ3sUeylLEXYmvA1VT1+q3b2m+1tGPxqrZGVOxKgbE7a+L0YfuCq+JVYWzxlNm6zQQ==",
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.4.2.tgz",
+			"integrity": "sha512-ADHaOwqEcVc71uTfySzSowA/RdxUpCxhxa2FNLiin9vWLB1uLPad3we+JSSROq5+SrL9iYPdZZF8bdKM7XABTQ==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^25.2.1",
-				"jest-regex-util": "^25.2.1",
-				"jest-snapshot": "^25.2.1"
+				"@jest/types": "^26.3.0",
+				"jest-regex-util": "^26.0.0",
+				"jest-snapshot": "^26.4.2"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-25.2.1.tgz",
-					"integrity": "sha512-WuGFGJ3Rrycg+5ZwQTWKjr21M9psANPAWYD28K42hSeUzhv1H591VXIoq0tjs00mydhNOgVOkKSpzRS3CrOYFw==",
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^1.1.1",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
 						"@types/yargs": "^15.0.0",
-						"chalk": "^3.0.0"
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.4",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-					"integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+					"version": "15.0.7",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
+					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -5614,9 +6130,9 @@
 					}
 				},
 				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
@@ -5645,9 +6161,9 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -5656,48 +6172,59 @@
 			}
 		},
 		"jest-runner": {
-			"version": "25.2.2",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-25.2.2.tgz",
-			"integrity": "sha512-U0UACNQK3WovPpNvOsf57qfk815ZfMAq2oH3kQUTZEY7L07nVnY9tVmDvI1RBh1JtkNBqUCSoqYjlTpiBhhghQ==",
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.4.2.tgz",
+			"integrity": "sha512-FgjDHeVknDjw1gRAYaoUoShe1K3XUuFMkIaXbdhEys+1O4bEJS8Avmn4lBwoMfL8O5oFTdWYKcf3tEJyyYyk8g==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^25.2.1",
-				"@jest/environment": "^25.2.1",
-				"@jest/test-result": "^25.2.1",
-				"@jest/types": "^25.2.1",
-				"chalk": "^3.0.0",
+				"@jest/console": "^26.3.0",
+				"@jest/environment": "^26.3.0",
+				"@jest/test-result": "^26.3.0",
+				"@jest/types": "^26.3.0",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"emittery": "^0.7.1",
 				"exit": "^0.1.2",
-				"graceful-fs": "^4.2.3",
-				"jest-config": "^25.2.2",
-				"jest-docblock": "^25.2.0",
-				"jest-haste-map": "^25.2.1",
-				"jest-jasmine2": "^25.2.2",
-				"jest-leak-detector": "^25.2.1",
-				"jest-message-util": "^25.2.1",
-				"jest-resolve": "^25.2.1",
-				"jest-runtime": "^25.2.2",
-				"jest-util": "^25.2.1",
-				"jest-worker": "^25.2.1",
+				"graceful-fs": "^4.2.4",
+				"jest-config": "^26.4.2",
+				"jest-docblock": "^26.0.0",
+				"jest-haste-map": "^26.3.0",
+				"jest-leak-detector": "^26.4.2",
+				"jest-message-util": "^26.3.0",
+				"jest-resolve": "^26.4.0",
+				"jest-runtime": "^26.4.2",
+				"jest-util": "^26.3.0",
+				"jest-worker": "^26.3.0",
 				"source-map-support": "^0.5.6",
 				"throat": "^5.0.0"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-25.2.1.tgz",
-					"integrity": "sha512-WuGFGJ3Rrycg+5ZwQTWKjr21M9psANPAWYD28K42hSeUzhv1H591VXIoq0tjs00mydhNOgVOkKSpzRS3CrOYFw==",
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^1.1.1",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
 						"@types/yargs": "^15.0.0",
-						"chalk": "^3.0.0"
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.4",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-					"integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+					"version": "15.0.7",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
+					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -5714,9 +6241,9 @@
 					}
 				},
 				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
@@ -5736,12 +6263,6 @@
 					"version": "1.1.4",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"graceful-fs": {
-					"version": "4.2.3",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-					"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
 					"dev": true
 				},
 				"has-flag": {
@@ -5751,9 +6272,9 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -5762,54 +6283,65 @@
 			}
 		},
 		"jest-runtime": {
-			"version": "25.2.2",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-25.2.2.tgz",
-			"integrity": "sha512-k0LgYDw8nDOGJRPhFlsitzqOxkDGxyVQQG1O39ToHsuApVkZHguYEw4tNXU8Pc4GdU9/ua9ke6nUjHNiByE8bg==",
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.4.2.tgz",
+			"integrity": "sha512-4Pe7Uk5a80FnbHwSOk7ojNCJvz3Ks2CNQWT5Z7MJo4tX0jb3V/LThKvD9tKPNVNyeMH98J/nzGlcwc00R2dSHQ==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^25.2.1",
-				"@jest/environment": "^25.2.1",
-				"@jest/source-map": "^25.2.1",
-				"@jest/test-result": "^25.2.1",
-				"@jest/transform": "^25.2.1",
-				"@jest/types": "^25.2.1",
+				"@jest/console": "^26.3.0",
+				"@jest/environment": "^26.3.0",
+				"@jest/fake-timers": "^26.3.0",
+				"@jest/globals": "^26.4.2",
+				"@jest/source-map": "^26.3.0",
+				"@jest/test-result": "^26.3.0",
+				"@jest/transform": "^26.3.0",
+				"@jest/types": "^26.3.0",
 				"@types/yargs": "^15.0.0",
-				"chalk": "^3.0.0",
+				"chalk": "^4.0.0",
 				"collect-v8-coverage": "^1.0.0",
 				"exit": "^0.1.2",
 				"glob": "^7.1.3",
-				"graceful-fs": "^4.2.3",
-				"jest-config": "^25.2.2",
-				"jest-haste-map": "^25.2.1",
-				"jest-message-util": "^25.2.1",
-				"jest-mock": "^25.2.1",
-				"jest-regex-util": "^25.2.1",
-				"jest-resolve": "^25.2.1",
-				"jest-snapshot": "^25.2.1",
-				"jest-util": "^25.2.1",
-				"jest-validate": "^25.2.1",
-				"realpath-native": "^2.0.0",
+				"graceful-fs": "^4.2.4",
+				"jest-config": "^26.4.2",
+				"jest-haste-map": "^26.3.0",
+				"jest-message-util": "^26.3.0",
+				"jest-mock": "^26.3.0",
+				"jest-regex-util": "^26.0.0",
+				"jest-resolve": "^26.4.0",
+				"jest-snapshot": "^26.4.2",
+				"jest-util": "^26.3.0",
+				"jest-validate": "^26.4.2",
 				"slash": "^3.0.0",
 				"strip-bom": "^4.0.0",
 				"yargs": "^15.3.1"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-25.2.1.tgz",
-					"integrity": "sha512-WuGFGJ3Rrycg+5ZwQTWKjr21M9psANPAWYD28K42hSeUzhv1H591VXIoq0tjs00mydhNOgVOkKSpzRS3CrOYFw==",
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^1.1.1",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
 						"@types/yargs": "^15.0.0",
-						"chalk": "^3.0.0"
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.4",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-					"integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+					"version": "15.0.7",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
+					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -5826,9 +6358,9 @@
 					}
 				},
 				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
@@ -5848,12 +6380,6 @@
 					"version": "1.1.4",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"graceful-fs": {
-					"version": "4.2.3",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-					"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
 					"dev": true
 				},
 				"has-flag": {
@@ -5869,9 +6395,9 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -5880,49 +6406,64 @@
 			}
 		},
 		"jest-serializer": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-25.2.1.tgz",
-			"integrity": "sha512-fibDi7M5ffx6c/P66IkvR4FKkjG5ldePAK1WlbNoaU4GZmIAkS9Le/frAwRUFEX0KdnisSPWf+b1RC5jU7EYJQ==",
-			"dev": true
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.3.0.tgz",
+			"integrity": "sha512-IDRBQBLPlKa4flg77fqg0n/pH87tcRKwe8zxOVTWISxGpPHYkRZ1dXKyh04JOja7gppc60+soKVZ791mruVdow==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*",
+				"graceful-fs": "^4.2.4"
+			}
 		},
 		"jest-snapshot": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-25.2.1.tgz",
-			"integrity": "sha512-5Wd8SEJVTXqQvzkQpuYqQt1QTlRj2XVUV/iaEzO+AeSVg6g5pQWu0z2iLdSBlVeWRrX0MyZn6dhxYGwEq4wW0w==",
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.4.2.tgz",
+			"integrity": "sha512-N6Uub8FccKlf5SBFnL2Ri/xofbaA68Cc3MGjP/NuwgnsvWh+9hLIR/DhrxbSiKXMY9vUW5dI6EW1eHaDHqe9sg==",
 			"dev": true,
 			"requires": {
 				"@babel/types": "^7.0.0",
-				"@jest/types": "^25.2.1",
-				"@types/prettier": "^1.19.0",
-				"chalk": "^3.0.0",
-				"expect": "^25.2.1",
-				"jest-diff": "^25.2.1",
-				"jest-get-type": "^25.2.1",
-				"jest-matcher-utils": "^25.2.1",
-				"jest-message-util": "^25.2.1",
-				"jest-resolve": "^25.2.1",
-				"make-dir": "^3.0.0",
+				"@jest/types": "^26.3.0",
+				"@types/prettier": "^2.0.0",
+				"chalk": "^4.0.0",
+				"expect": "^26.4.2",
+				"graceful-fs": "^4.2.4",
+				"jest-diff": "^26.4.2",
+				"jest-get-type": "^26.3.0",
+				"jest-haste-map": "^26.3.0",
+				"jest-matcher-utils": "^26.4.2",
+				"jest-message-util": "^26.3.0",
+				"jest-resolve": "^26.4.0",
 				"natural-compare": "^1.4.0",
-				"pretty-format": "^25.2.1",
-				"semver": "^6.3.0"
+				"pretty-format": "^26.4.2",
+				"semver": "^7.3.2"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-25.2.1.tgz",
-					"integrity": "sha512-WuGFGJ3Rrycg+5ZwQTWKjr21M9psANPAWYD28K42hSeUzhv1H591VXIoq0tjs00mydhNOgVOkKSpzRS3CrOYFw==",
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^1.1.1",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
 						"@types/yargs": "^15.0.0",
-						"chalk": "^3.0.0"
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.4",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-					"integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+					"version": "15.0.7",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
+					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -5939,9 +6480,9 @@
 					}
 				},
 				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
@@ -5964,9 +6505,9 @@
 					"dev": true
 				},
 				"diff-sequences": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.1.tgz",
-					"integrity": "sha512-foe7dXnGlSh3jR1ovJmdv+77VQj98eKCHHwJPbZ2eEf0fHwKbkZicpPxEch9smZ+n2dnF6QFwkOQdLq9hpeJUg==",
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.3.0.tgz",
+					"integrity": "sha512-5j5vdRcw3CNctePNYN0Wy2e/JbWT6cAYnXv5OuqPhDpyCGc0uLu2TK0zOCJWNB9kOIfYMSpIulRaDgIi4HJ6Ig==",
 					"dev": true
 				},
 				"has-flag": {
@@ -5976,42 +6517,42 @@
 					"dev": true
 				},
 				"jest-diff": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.2.1.tgz",
-					"integrity": "sha512-e/TU8VLBBGQQS9tXA5B5LeT806jh7CHUeHbBfrU9UvA2zTbOTRz71UD6fAP1HAhzUEyCVLU2ZP5e8X16A9b0Fg==",
+					"version": "26.4.2",
+					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.4.2.tgz",
+					"integrity": "sha512-6T1XQY8U28WH0Z5rGpQ+VqZSZz8EN8rZcBtfvXaOkbwxIEeRre6qnuZQlbY1AJ4MKDxQF8EkrCvK+hL/VkyYLQ==",
 					"dev": true,
 					"requires": {
-						"chalk": "^3.0.0",
-						"diff-sequences": "^25.2.1",
-						"jest-get-type": "^25.2.1",
-						"pretty-format": "^25.2.1"
+						"chalk": "^4.0.0",
+						"diff-sequences": "^26.3.0",
+						"jest-get-type": "^26.3.0",
+						"pretty-format": "^26.4.2"
 					}
 				},
 				"jest-get-type": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.1.tgz",
-					"integrity": "sha512-EYjTiqcDTCRJDcSNKbLTwn/LcDPEE7ITk8yRMNAOjEsN6yp+Uu+V1gx4djwnuj/DvWg0YGmqaBqPVGsPxlvE7w==",
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+					"integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
 					"dev": true
 				},
 				"jest-matcher-utils": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-25.2.1.tgz",
-					"integrity": "sha512-uuoYY8W6eeVxHUEOvrKIVVTl9X6RP+ohQn2Ta2W8OOLMN6oA8pZUKQEPGxLsSqB3RKfpTueurMLrxDTEZGllsA==",
+					"version": "26.4.2",
+					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.4.2.tgz",
+					"integrity": "sha512-KcbNqWfWUG24R7tu9WcAOKKdiXiXCbMvQYT6iodZ9k1f7065k0keUOW6XpJMMvah+hTfqkhJhRXmA3r3zMAg0Q==",
 					"dev": true,
 					"requires": {
-						"chalk": "^3.0.0",
-						"jest-diff": "^25.2.1",
-						"jest-get-type": "^25.2.1",
-						"pretty-format": "^25.2.1"
+						"chalk": "^4.0.0",
+						"jest-diff": "^26.4.2",
+						"jest-get-type": "^26.3.0",
+						"pretty-format": "^26.4.2"
 					}
 				},
 				"pretty-format": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.2.1.tgz",
-					"integrity": "sha512-YS+e9oGYIbEeAFgqTU8qeZ3DN2Pz0iaD81ox+iUjLIXVJWeB7Ro/2AnfxRnl/yJJ5R674d7E3jLPuh6bwg0+qw==",
+					"version": "26.4.2",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+					"integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^25.2.1",
+						"@jest/types": "^26.3.0",
 						"ansi-regex": "^5.0.0",
 						"ansi-styles": "^4.0.0",
 						"react-is": "^16.12.0"
@@ -6024,9 +6565,9 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -6035,33 +6576,45 @@
 			}
 		},
 		"jest-util": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-25.2.1.tgz",
-			"integrity": "sha512-oFVMSY/7flrSgEE/B+RApaBZOdLURXRnXCf4COV5td9uRidxudyjA64I1xk2h9Pf3jloSArm96e2FKAbFs0DYg==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.3.0.tgz",
+			"integrity": "sha512-4zpn6bwV0+AMFN0IYhH/wnzIQzRaYVrz1A8sYnRnj4UXDXbOVtWmlaZkO9mipFqZ13okIfN87aDoJWB7VH6hcw==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^25.2.1",
-				"chalk": "^3.0.0",
+				"@jest/types": "^26.3.0",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"graceful-fs": "^4.2.4",
 				"is-ci": "^2.0.0",
-				"make-dir": "^3.0.0"
+				"micromatch": "^4.0.2"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-25.2.1.tgz",
-					"integrity": "sha512-WuGFGJ3Rrycg+5ZwQTWKjr21M9psANPAWYD28K42hSeUzhv1H591VXIoq0tjs00mydhNOgVOkKSpzRS3CrOYFw==",
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^1.1.1",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
 						"@types/yargs": "^15.0.0",
-						"chalk": "^3.0.0"
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.4",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-					"integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+					"version": "15.0.7",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
+					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -6078,9 +6631,9 @@
 					}
 				},
 				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
@@ -6109,9 +6662,9 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -6120,35 +6673,45 @@
 			}
 		},
 		"jest-validate": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-25.2.1.tgz",
-			"integrity": "sha512-vGtNFPyvylFfTFFfptzqCy5S3cP/N5JJVwm8gsXeZq8jMmvUngfWtuw+Tr5Wjo+dqOle23td8BE0ruGnsONDmw==",
+			"version": "26.4.2",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.4.2.tgz",
+			"integrity": "sha512-blft+xDX7XXghfhY0mrsBCYhX365n8K5wNDC4XAcNKqqjEzsRUSXP44m6PL0QJEW2crxQFLLztVnJ4j7oPlQrQ==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^25.2.1",
-				"camelcase": "^5.3.1",
-				"chalk": "^3.0.0",
-				"jest-get-type": "^25.2.1",
+				"@jest/types": "^26.3.0",
+				"camelcase": "^6.0.0",
+				"chalk": "^4.0.0",
+				"jest-get-type": "^26.3.0",
 				"leven": "^3.1.0",
-				"pretty-format": "^25.2.1"
+				"pretty-format": "^26.4.2"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-25.2.1.tgz",
-					"integrity": "sha512-WuGFGJ3Rrycg+5ZwQTWKjr21M9psANPAWYD28K42hSeUzhv1H591VXIoq0tjs00mydhNOgVOkKSpzRS3CrOYFw==",
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^1.1.1",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
 						"@types/yargs": "^15.0.0",
-						"chalk": "^3.0.0"
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.4",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-					"integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+					"version": "15.0.7",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
+					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -6164,10 +6727,16 @@
 						"color-convert": "^2.0.1"
 					}
 				},
+				"camelcase": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
+					"integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==",
+					"dev": true
+				},
 				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
@@ -6196,18 +6765,18 @@
 					"dev": true
 				},
 				"jest-get-type": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.1.tgz",
-					"integrity": "sha512-EYjTiqcDTCRJDcSNKbLTwn/LcDPEE7ITk8yRMNAOjEsN6yp+Uu+V1gx4djwnuj/DvWg0YGmqaBqPVGsPxlvE7w==",
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+					"integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
 					"dev": true
 				},
 				"pretty-format": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.2.1.tgz",
-					"integrity": "sha512-YS+e9oGYIbEeAFgqTU8qeZ3DN2Pz0iaD81ox+iUjLIXVJWeB7Ro/2AnfxRnl/yJJ5R674d7E3jLPuh6bwg0+qw==",
+					"version": "26.4.2",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+					"integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^25.2.1",
+						"@jest/types": "^26.3.0",
 						"ansi-regex": "^5.0.0",
 						"ansi-styles": "^4.0.0",
 						"react-is": "^16.12.0"
@@ -6220,9 +6789,9 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -6231,35 +6800,46 @@
 			}
 		},
 		"jest-watcher": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-25.2.1.tgz",
-			"integrity": "sha512-m35rftCYE2EEh01+IIpQMpdB9VXBAjITZvgP4drd/LI3JEJIdd0Pkf/qJZ3oiMQJdqmuwYcTqE+BL40MxVv83Q==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.3.0.tgz",
+			"integrity": "sha512-XnLdKmyCGJ3VoF6G/p5ohbJ04q/vv5aH9ENI+i6BL0uu9WWB6Z7Z2lhQQk0d2AVZcRGp1yW+/TsoToMhBFPRdQ==",
 			"dev": true,
 			"requires": {
-				"@jest/test-result": "^25.2.1",
-				"@jest/types": "^25.2.1",
+				"@jest/test-result": "^26.3.0",
+				"@jest/types": "^26.3.0",
+				"@types/node": "*",
 				"ansi-escapes": "^4.2.1",
-				"chalk": "^3.0.0",
-				"jest-util": "^25.2.1",
-				"string-length": "^3.1.0"
+				"chalk": "^4.0.0",
+				"jest-util": "^26.3.0",
+				"string-length": "^4.0.1"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-25.2.1.tgz",
-					"integrity": "sha512-WuGFGJ3Rrycg+5ZwQTWKjr21M9psANPAWYD28K42hSeUzhv1H591VXIoq0tjs00mydhNOgVOkKSpzRS3CrOYFw==",
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^1.1.1",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
 						"@types/yargs": "^15.0.0",
-						"chalk": "^3.0.0"
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-report": "*"
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.4",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-					"integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+					"version": "15.0.7",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
+					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -6276,9 +6856,9 @@
 					}
 				},
 				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
@@ -6307,9 +6887,9 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -6318,11 +6898,12 @@
 			}
 		},
 		"jest-worker": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.2.1.tgz",
-			"integrity": "sha512-IHnpekk8H/hCUbBlfeaPZzU6v75bqwJp3n4dUrQuQOAgOneI4tx3jV2o8pvlXnDfcRsfkFIUD//HWXpCmR+evQ==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.3.0.tgz",
+			"integrity": "sha512-Vmpn2F6IASefL+DVBhPzI2J9/GJUsqzomdeN+P+dK8/jKxbh8R3BtFnx3FIta7wYlPU62cpJMJQo4kuOowcMnw==",
 			"dev": true,
 			"requires": {
+				"@types/node": "*",
 				"merge-stream": "^2.0.0",
 				"supports-color": "^7.0.0"
 			},
@@ -6334,9 +6915,9 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -6351,9 +6932,9 @@
 			"dev": true
 		},
 		"js-yaml": {
-			"version": "3.13.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+			"version": "3.14.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+			"integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
 			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
@@ -6376,9 +6957,9 @@
 			"dev": true
 		},
 		"jsdoc": {
-			"version": "3.6.4",
-			"resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.4.tgz",
-			"integrity": "sha512-3G9d37VHv7MFdheviDCjUfQoIjdv4TC5zTTf5G9VODLtOnVS6La1eoYBDlbWfsRT3/Xo+j2MIqki2EV12BZfwA==",
+			"version": "3.6.6",
+			"resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.6.tgz",
+			"integrity": "sha512-znR99e1BHeyEkSvgDDpX0sTiTu+8aQyDl9DawrkOGZTTW8hv0deIFXx87114zJ7gRaDZKVQD/4tr1ifmJp9xhQ==",
 			"dev": true,
 			"requires": {
 				"@babel/parser": "^7.9.4",
@@ -6414,121 +6995,86 @@
 					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
 					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
 					"dev": true
-				},
-				"strip-json-comments": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.0.tgz",
-					"integrity": "sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==",
-					"dev": true
 				}
 			}
 		},
 		"jsdoc-api": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-5.0.4.tgz",
-			"integrity": "sha512-1KMwLnfo0FyhF06TQKzqIm8BiY1yoMIGICxRdJHUjzskaHMzHMmpLlmNFgzoa4pAC8t1CDPK5jWuQTvv1pBsEQ==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-6.0.0.tgz",
+			"integrity": "sha512-zvfB63nAc9e+Rv2kKmJfE6tmo4x8KFho5vKr6VfYTlCCgqtrfPv0McCdqT4betUT9rWtw0zGkNUVkVqeQipY6Q==",
 			"dev": true,
 			"requires": {
-				"array-back": "^4.0.0",
-				"cache-point": "^1.0.0",
+				"array-back": "^4.0.1",
+				"cache-point": "^2.0.0",
 				"collect-all": "^1.0.3",
-				"file-set": "^2.0.1",
+				"file-set": "^4.0.1",
 				"fs-then-native": "^2.0.0",
-				"jsdoc": "^3.6.3",
-				"object-to-spawn-args": "^1.1.1",
+				"jsdoc": "^3.6.4",
+				"object-to-spawn-args": "^2.0.0",
 				"temp-path": "^1.0.0",
-				"walk-back": "^3.0.1"
-			},
-			"dependencies": {
-				"file-set": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/file-set/-/file-set-2.0.1.tgz",
-					"integrity": "sha512-XgOUUpgR6FbbfYcniLw0qm1Am7PnNYIAkd+eXxRt42LiYhjaso0WiuQ+VmrNdtwotyM+cLCfZ56AZrySP3QnKA==",
-					"dev": true,
-					"requires": {
-						"array-back": "^2.0.0",
-						"glob": "^7.1.3"
-					},
-					"dependencies": {
-						"array-back": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-							"integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
-							"dev": true,
-							"requires": {
-								"typical": "^2.6.1"
-							}
-						}
-					}
-				},
-				"walk-back": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/walk-back/-/walk-back-3.0.1.tgz",
-					"integrity": "sha512-umiNB2qLO731Sxbp6cfZ9pwURJzTnftxE4Gc7hq8n/ehkuXC//s9F65IEIJA2ZytQZ1ZOsm/Fju4IWx0bivkUQ==",
-					"dev": true
-				}
+				"walk-back": "^4.0.0"
 			}
 		},
 		"jsdoc-parse": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-4.0.1.tgz",
-			"integrity": "sha512-qIObw8yqYZjrP2qxWROB5eLQFLTUX2jRGLhW9hjo2CC2fQVlskidCIzjCoctwsDvauBp2a/lR31jkSleczSo8Q==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-5.0.0.tgz",
+			"integrity": "sha512-Khw8c3glrTeA3/PfUJUBvhrMhWpSClORBUvL4pvq2wFcqvUVmA96wxnMkCno2GfZY4pnd8BStK5WGKGyn4Vckg==",
 			"dev": true,
 			"requires": {
-				"array-back": "^4.0.0",
+				"array-back": "^4.0.1",
 				"lodash.omit": "^4.5.0",
 				"lodash.pick": "^4.4.0",
 				"reduce-extract": "^1.0.0",
-				"sort-array": "^2.0.0",
+				"sort-array": "^4.1.1",
 				"test-value": "^3.0.0"
 			}
 		},
 		"jsdoc-to-markdown": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-5.0.3.tgz",
-			"integrity": "sha512-tQv5tBV0fTYidRQtE60lJKxE98mmuLcYuITFDKQiDPE9hGccpeEGUNFcVkInq1vigyuPnZmt79bQ8wv2GKjY0Q==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-6.0.1.tgz",
+			"integrity": "sha512-hUI2PAR5n/KlmQU3mAWO9i3D7jVbhyvUHfQ6oYVBt+wnnsyxpsAuhCODY1ryLOb2U9OPJd4GIK9mL2hqy7fHDg==",
 			"dev": true,
 			"requires": {
 				"array-back": "^4.0.1",
 				"command-line-tool": "^0.8.0",
 				"config-master": "^3.1.0",
-				"dmd": "^4.0.5",
-				"jsdoc-api": "^5.0.4",
-				"jsdoc-parse": "^4.0.1",
+				"dmd": "^5.0.1",
+				"jsdoc-api": "^6.0.0",
+				"jsdoc-parse": "^5.0.0",
 				"walk-back": "^4.0.0"
 			}
 		},
 		"jsdom": {
-			"version": "15.2.1",
-			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-15.2.1.tgz",
-			"integrity": "sha512-fAl1W0/7T2G5vURSyxBzrJ1LSdQn6Tr5UX/xD4PXDx/PDgwygedfW6El/KIj3xJ7FU61TTYnc/l/B7P49Eqt6g==",
+			"version": "16.4.0",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.4.0.tgz",
+			"integrity": "sha512-lYMm3wYdgPhrl7pDcRmvzPhhrGVBeVhPIqeHjzeiHN3DFmD1RBpbExbi8vU7BJdH8VAZYovR8DMt0PNNDM7k8w==",
 			"dev": true,
 			"requires": {
-				"abab": "^2.0.0",
-				"acorn": "^7.1.0",
-				"acorn-globals": "^4.3.2",
-				"array-equal": "^1.0.0",
-				"cssom": "^0.4.1",
-				"cssstyle": "^2.0.0",
-				"data-urls": "^1.1.0",
-				"domexception": "^1.0.1",
-				"escodegen": "^1.11.1",
-				"html-encoding-sniffer": "^1.0.2",
+				"abab": "^2.0.3",
+				"acorn": "^7.1.1",
+				"acorn-globals": "^6.0.0",
+				"cssom": "^0.4.4",
+				"cssstyle": "^2.2.0",
+				"data-urls": "^2.0.0",
+				"decimal.js": "^10.2.0",
+				"domexception": "^2.0.1",
+				"escodegen": "^1.14.1",
+				"html-encoding-sniffer": "^2.0.1",
+				"is-potential-custom-element-name": "^1.0.0",
 				"nwsapi": "^2.2.0",
-				"parse5": "5.1.0",
-				"pn": "^1.1.0",
-				"request": "^2.88.0",
-				"request-promise-native": "^1.0.7",
-				"saxes": "^3.1.9",
-				"symbol-tree": "^3.2.2",
+				"parse5": "5.1.1",
+				"request": "^2.88.2",
+				"request-promise-native": "^1.0.8",
+				"saxes": "^5.0.0",
+				"symbol-tree": "^3.2.4",
 				"tough-cookie": "^3.0.1",
-				"w3c-hr-time": "^1.0.1",
-				"w3c-xmlserializer": "^1.1.2",
-				"webidl-conversions": "^4.0.2",
+				"w3c-hr-time": "^1.0.2",
+				"w3c-xmlserializer": "^2.0.0",
+				"webidl-conversions": "^6.1.0",
 				"whatwg-encoding": "^1.0.5",
 				"whatwg-mimetype": "^2.3.0",
-				"whatwg-url": "^7.0.0",
-				"ws": "^7.0.0",
+				"whatwg-url": "^8.0.0",
+				"ws": "^7.2.3",
 				"xml-name-validator": "^3.0.0"
 			}
 		},
@@ -6536,6 +7082,12 @@
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
 			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+			"dev": true
+		},
+		"json-parse-even-better-errors": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
 			"dev": true
 		},
 		"json-schema": {
@@ -6563,20 +7115,12 @@
 			"dev": true
 		},
 		"json5": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.2.tgz",
-			"integrity": "sha512-MoUOQ4WdiN3yxhm7NEVJSJrieAo5hNSLQ5sj05OTRHPL9HOBy8u4Bu88jsC1jvqAdN+E1bJmsUcZH+1HQxliqQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+			"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
 			"dev": true,
 			"requires": {
-				"minimist": "^1.2.5"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.2.5",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-					"dev": true
-				}
+				"minimist": "^1.2.0"
 			}
 		},
 		"jsprim": {
@@ -6592,12 +7136,12 @@
 			}
 		},
 		"jsx-ast-utils": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.3.tgz",
-			"integrity": "sha512-EdIHFMm+1BPynpKOpdPqiOsvnIrInRGJD7bzPZdPkjitQEqpdpUuFpq4T0npZFKTiB3RhWFdGN+oqOJIdhDhQA==",
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.4.1.tgz",
+			"integrity": "sha512-z1xSldJ6imESSzOjd3NNkieVJKRlKYSOtMG8SFyCj2FIrvSaSuli/WjpBkEzCBoR9bYYYFgqJw61Xhu7Lcgk+w==",
 			"dev": true,
 			"requires": {
-				"array-includes": "^3.0.3",
+				"array-includes": "^3.1.1",
 				"object.assign": "^4.1.0"
 			}
 		},
@@ -6622,6 +7166,21 @@
 			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
 			"dev": true
 		},
+		"language-subtag-registry": {
+			"version": "0.3.20",
+			"resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.20.tgz",
+			"integrity": "sha512-KPMwROklF4tEx283Xw0pNKtfTj1gZ4UByp4EsIFWLgBavJltF4TiYPc39k06zSTsLzxTVXXDSpbwaQXaFB4Qeg==",
+			"dev": true
+		},
+		"language-tags": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.5.tgz",
+			"integrity": "sha1-0yHbxNowuovzAk4ED6XBRmH5GTo=",
+			"dev": true,
+			"requires": {
+				"language-subtag-registry": "~0.3.2"
+			}
+		},
 		"leven": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -6629,14 +7188,20 @@
 			"dev": true
 		},
 		"levn": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+			"integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2"
+				"prelude-ls": "^1.2.1",
+				"type-check": "~0.4.0"
 			}
+		},
+		"lines-and-columns": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+			"integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+			"dev": true
 		},
 		"linkify-it": {
 			"version": "2.2.0",
@@ -6647,19 +7212,32 @@
 				"uc.micro": "^1.0.1"
 			}
 		},
-		"locate-path": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+		"load-json-file": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+			"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
 			"dev": true,
 			"requires": {
-				"p-locate": "^4.1.0"
+				"graceful-fs": "^4.1.2",
+				"parse-json": "^2.2.0",
+				"pify": "^2.0.0",
+				"strip-bom": "^3.0.0"
+			}
+		},
+		"locate-path": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+			"dev": true,
+			"requires": {
+				"p-locate": "^2.0.0",
+				"path-exists": "^3.0.0"
 			}
 		},
 		"lodash": {
-			"version": "4.17.15",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+			"version": "4.17.20",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
 		},
 		"lodash.camelcase": {
 			"version": "4.3.0",
@@ -6691,22 +7269,21 @@
 			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
 			"dev": true
 		},
-		"lolex": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
-			"integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
-			"dev": true,
-			"requires": {
-				"@sinonjs/commons": "^1.7.0"
-			}
-		},
 		"make-dir": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
-			"integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+			"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
 			"dev": true,
 			"requires": {
 				"semver": "^6.0.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
 			}
 		},
 		"makeerror": {
@@ -6753,9 +7330,9 @@
 			"dev": true
 		},
 		"marked": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
-			"integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-1.2.0.tgz",
+			"integrity": "sha512-tiRxakgbNPBr301ihe/785NntvYyhxlqcL3YaC8CaxJQh7kiaEtrN9B/eK2I2943Yjkh5gw25chYFDQhOMCwMA==",
 			"dev": true
 		},
 		"mdurl": {
@@ -6770,6 +7347,12 @@
 			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
 			"dev": true
 		},
+		"merge2": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+			"dev": true
+		},
 		"micromatch": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
@@ -6781,18 +7364,18 @@
 			}
 		},
 		"mime-db": {
-			"version": "1.40.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-			"integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
+			"version": "1.44.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+			"integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
 			"dev": true
 		},
 		"mime-types": {
-			"version": "2.1.24",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
-			"integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+			"version": "2.1.27",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+			"integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
 			"dev": true,
 			"requires": {
-				"mime-db": "1.40.0"
+				"mime-db": "1.44.0"
 			}
 		},
 		"mimic-fn": {
@@ -6844,14 +7427,6 @@
 			"dev": true,
 			"requires": {
 				"minimist": "^1.2.5"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.2.5",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-					"dev": true
-				}
 			}
 		},
 		"mkdirp2": {
@@ -6870,12 +7445,6 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/mustache/-/mustache-4.0.1.tgz",
 			"integrity": "sha512-yL5VE97+OXn4+Er3THSmTdCFCtx5hHWzrolvH+JObZnUYwuaG7XV+Ch4fR2cIrcYI0tFHxS7iyFYl14bW8y2sA=="
-		},
-		"mute-stream": {
-			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
-			"dev": true
 		},
 		"nanomatch": {
 			"version": "1.2.13",
@@ -6903,9 +7472,9 @@
 			"dev": true
 		},
 		"neo-async": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-			"integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
 			"dev": true
 		},
 		"nice-try": {
@@ -6927,17 +7496,18 @@
 			"dev": true
 		},
 		"node-notifier": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-6.0.0.tgz",
-			"integrity": "sha512-SVfQ/wMw+DesunOm5cKqr6yDcvUTDl/yc97ybGHMrteNEY6oekXpNpS3lZwgLlwz0FLgHoiW28ZpmBHUDg37cw==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.0.tgz",
+			"integrity": "sha512-46z7DUmcjoYdaWyXouuFNNfUo6eFa94t23c53c+lG/9Cvauk4a98rAUp9672X5dxGdQmLpPzTxzu8f/OeEPaFA==",
 			"dev": true,
 			"optional": true,
 			"requires": {
 				"growly": "^1.3.0",
-				"is-wsl": "^2.1.1",
-				"semver": "^6.3.0",
+				"is-wsl": "^2.2.0",
+				"semver": "^7.3.2",
 				"shellwords": "^0.1.1",
-				"which": "^1.3.1"
+				"uuid": "^8.3.0",
+				"which": "^2.0.2"
 			}
 		},
 		"normalize-package-data": {
@@ -6973,6 +7543,14 @@
 			"dev": true,
 			"requires": {
 				"path-key": "^2.0.0"
+			},
+			"dependencies": {
+				"path-key": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+					"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+					"dev": true
+				}
 			}
 		},
 		"nwsapi": {
@@ -7025,9 +7603,9 @@
 			"dev": true
 		},
 		"object-inspect": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-			"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
+			"integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
 			"dev": true
 		},
 		"object-keys": {
@@ -7037,9 +7615,9 @@
 			"dev": true
 		},
 		"object-to-spawn-args": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/object-to-spawn-args/-/object-to-spawn-args-1.1.1.tgz",
-			"integrity": "sha1-d9qIJ/Bz0BHJ4bFz+JV4FHAkZ4U=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/object-to-spawn-args/-/object-to-spawn-args-2.0.0.tgz",
+			"integrity": "sha512-ZMT4owlXg3JGegecLlAgAA/6BsdKHn63R3ayXcAa3zFkF7oUBHcSb0oxszeutYe0FO2c1lT5pwCuidLkC4Gx3g==",
 			"dev": true
 		},
 		"object-visit": {
@@ -7052,27 +7630,47 @@
 			}
 		},
 		"object.assign": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-			"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.2",
-				"function-bind": "^1.1.1",
-				"has-symbols": "^1.0.0",
-				"object-keys": "^1.0.11"
-			}
-		},
-		"object.entries": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.1.tgz",
-			"integrity": "sha512-ilqR7BgdyZetJutmDPfXCDffGa0/Yzl2ivVNpbx/g4UeWrCdRnFDUBrKJGLhGieRHDATnyZXWBeCb29k9CJysQ==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.1.tgz",
+			"integrity": "sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==",
 			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.0-next.1",
-				"function-bind": "^1.1.1",
+				"es-abstract": "^1.18.0-next.0",
+				"has-symbols": "^1.0.1",
+				"object-keys": "^1.1.1"
+			}
+		},
+		"object.entries": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.2.tgz",
+			"integrity": "sha512-BQdB9qKmb/HyNdMNWVr7O3+z5MUIx3aiegEIJqjMBbBf0YT9RRxTJSim4mzFqtyr7PDAHigq0N9dO0m0tRakQA==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.5",
 				"has": "^1.0.3"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.17.7",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+					"integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+					"dev": true,
+					"requires": {
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1",
+						"is-callable": "^1.2.2",
+						"is-regex": "^1.1.1",
+						"object-inspect": "^1.8.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.1",
+						"string.prototype.trimend": "^1.0.1",
+						"string.prototype.trimstart": "^1.0.1"
+					}
+				}
 			}
 		},
 		"object.pick": {
@@ -7097,80 +7695,22 @@
 			},
 			"dependencies": {
 				"es-abstract": {
-					"version": "1.17.4",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
-					"integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
+					"version": "1.17.7",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+					"integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
 					"dev": true,
 					"requires": {
 						"es-to-primitive": "^1.2.1",
 						"function-bind": "^1.1.1",
 						"has": "^1.0.3",
 						"has-symbols": "^1.0.1",
-						"is-callable": "^1.1.5",
-						"is-regex": "^1.0.5",
-						"object-inspect": "^1.7.0",
+						"is-callable": "^1.2.2",
+						"is-regex": "^1.1.1",
+						"object-inspect": "^1.8.0",
 						"object-keys": "^1.1.1",
-						"object.assign": "^4.1.0",
-						"string.prototype.trimleft": "^2.1.1",
-						"string.prototype.trimright": "^2.1.1"
-					}
-				},
-				"es-to-primitive": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-					"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-					"dev": true,
-					"requires": {
-						"is-callable": "^1.1.4",
-						"is-date-object": "^1.0.1",
-						"is-symbol": "^1.0.2"
-					}
-				},
-				"has-symbols": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-					"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-					"dev": true
-				},
-				"is-callable": {
-					"version": "1.1.5",
-					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-					"integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
-					"dev": true
-				},
-				"is-regex": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
-					"integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
-					"dev": true,
-					"requires": {
-						"has": "^1.0.3"
-					}
-				},
-				"object-inspect": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-					"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
-					"dev": true
-				},
-				"string.prototype.trimleft": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
-					"integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
-					"dev": true,
-					"requires": {
-						"define-properties": "^1.1.3",
-						"function-bind": "^1.1.1"
-					}
-				},
-				"string.prototype.trimright": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
-					"integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
-					"dev": true,
-					"requires": {
-						"define-properties": "^1.1.3",
-						"function-bind": "^1.1.1"
+						"object.assign": "^4.1.1",
+						"string.prototype.trimend": "^1.0.1",
+						"string.prototype.trimstart": "^1.0.1"
 					}
 				}
 			}
@@ -7185,33 +7725,27 @@
 			}
 		},
 		"onetime": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
-			"integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
 			"dev": true,
 			"requires": {
 				"mimic-fn": "^2.1.0"
 			}
 		},
 		"optionator": {
-			"version": "0.8.3",
-			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-			"integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+			"version": "0.9.1",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+			"integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
 			"dev": true,
 			"requires": {
-				"deep-is": "~0.1.3",
-				"fast-levenshtein": "~2.0.6",
-				"levn": "~0.3.0",
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2",
-				"word-wrap": "~1.2.3"
+				"deep-is": "^0.1.3",
+				"fast-levenshtein": "^2.0.6",
+				"levn": "^0.4.1",
+				"prelude-ls": "^1.2.1",
+				"type-check": "^0.4.0",
+				"word-wrap": "^1.2.3"
 			}
-		},
-		"os-tmpdir": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-			"dev": true
 		},
 		"p-each-series": {
 			"version": "2.1.0",
@@ -7226,27 +7760,27 @@
 			"dev": true
 		},
 		"p-limit": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-			"integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+			"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
 			"dev": true,
 			"requires": {
-				"p-try": "^2.0.0"
+				"p-try": "^1.0.0"
 			}
 		},
 		"p-locate": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 			"dev": true,
 			"requires": {
-				"p-limit": "^2.2.0"
+				"p-limit": "^1.1.0"
 			}
 		},
 		"p-try": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
 			"dev": true
 		},
 		"parent-module": {
@@ -7258,10 +7792,19 @@
 				"callsites": "^3.0.0"
 			}
 		},
+		"parse-json": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+			"dev": true,
+			"requires": {
+				"error-ex": "^1.2.0"
+			}
+		},
 		"parse5": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
-			"integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+			"integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
 			"dev": true
 		},
 		"pascalcase": {
@@ -7283,9 +7826,9 @@
 			"dev": true
 		},
 		"path-key": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
 			"dev": true
 		},
 		"path-parse": {
@@ -7293,6 +7836,15 @@
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
 			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
 			"dev": true
+		},
+		"path-type": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+			"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+			"dev": true,
+			"requires": {
+				"pify": "^2.0.0"
+			}
 		},
 		"performance-now": {
 			"version": "2.1.0",
@@ -7306,6 +7858,12 @@
 			"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
 			"dev": true
 		},
+		"pify": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+			"dev": true
+		},
 		"pirates": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
@@ -7316,19 +7874,13 @@
 			}
 		},
 		"pkg-dir": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-			"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
 			"dev": true,
 			"requires": {
-				"find-up": "^4.0.0"
+				"find-up": "^2.1.0"
 			}
-		},
-		"pn": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
-			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
-			"dev": true
 		},
 		"posix-character-classes": {
 			"version": "0.1.1",
@@ -7337,15 +7889,15 @@
 			"dev": true
 		},
 		"prelude-ls": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
 			"dev": true
 		},
 		"prettier": {
-			"version": "1.19.1",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-			"integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.2.tgz",
+			"integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==",
 			"dev": true
 		},
 		"prettier-linter-helpers": {
@@ -7394,9 +7946,9 @@
 			}
 		},
 		"psl": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
-			"integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw==",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
 			"dev": true
 		},
 		"pump": {
@@ -7427,11 +7979,26 @@
 			"integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==",
 			"dev": true
 		},
-		"realpath-native": {
+		"read-pkg": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-2.0.0.tgz",
-			"integrity": "sha512-v1SEYUOXXdbBZK8ZuNgO4TBjamPsiSgcFr0aP+tEKpQZK8vooEUqV6nm6Cv502mX4NF2EfsnVqtNAHG+/6Ur1Q==",
-			"dev": true
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+			"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+			"dev": true,
+			"requires": {
+				"load-json-file": "^2.0.0",
+				"normalize-package-data": "^2.3.2",
+				"path-type": "^2.0.0"
+			}
+		},
+		"read-pkg-up": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+			"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+			"dev": true,
+			"requires": {
+				"find-up": "^2.0.0",
+				"read-pkg": "^2.0.0"
+			}
 		},
 		"reduce-extract": {
 			"version": "1.0.0",
@@ -7506,9 +8073,9 @@
 			}
 		},
 		"regenerator-runtime": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-			"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+			"version": "0.13.7",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+			"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
 			"dev": true
 		},
 		"regex-not": {
@@ -7522,9 +8089,9 @@
 			}
 		},
 		"regexpp": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
-			"integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+			"integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
 			"dev": true
 		},
 		"remove-trailing-separator": {
@@ -7546,9 +8113,9 @@
 			"dev": true
 		},
 		"request": {
-			"version": "2.88.0",
-			"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-			"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+			"version": "2.88.2",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+			"integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
 			"dev": true,
 			"requires": {
 				"aws-sign2": "~0.7.0",
@@ -7558,7 +8125,7 @@
 				"extend": "~3.0.2",
 				"forever-agent": "~0.6.1",
 				"form-data": "~2.3.2",
-				"har-validator": "~5.1.0",
+				"har-validator": "~5.1.3",
 				"http-signature": "~1.2.0",
 				"is-typedarray": "~1.0.0",
 				"isstream": "~0.1.2",
@@ -7568,45 +8135,45 @@
 				"performance-now": "^2.1.0",
 				"qs": "~6.5.2",
 				"safe-buffer": "^5.1.2",
-				"tough-cookie": "~2.4.3",
+				"tough-cookie": "~2.5.0",
 				"tunnel-agent": "^0.6.0",
 				"uuid": "^3.3.2"
 			},
 			"dependencies": {
-				"punycode": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-					"dev": true
-				},
 				"tough-cookie": {
-					"version": "2.4.3",
-					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-					"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+					"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
 					"dev": true,
 					"requires": {
-						"psl": "^1.1.24",
-						"punycode": "^1.4.1"
+						"psl": "^1.1.28",
+						"punycode": "^2.1.1"
 					}
+				},
+				"uuid": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+					"dev": true
 				}
 			}
 		},
 		"request-promise-core": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
-			"integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
+			"integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.17.15"
+				"lodash": "^4.17.19"
 			}
 		},
 		"request-promise-native": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.8.tgz",
-			"integrity": "sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==",
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
+			"integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
 			"dev": true,
 			"requires": {
-				"request-promise-core": "1.1.3",
+				"request-promise-core": "1.1.4",
 				"stealthy-require": "^1.1.1",
 				"tough-cookie": "^2.3.3"
 			},
@@ -7645,9 +8212,9 @@
 			}
 		},
 		"resolve": {
-			"version": "1.12.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
-			"integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+			"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
 			"dev": true,
 			"requires": {
 				"path-parse": "^1.0.6"
@@ -7682,20 +8249,16 @@
 			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
 			"dev": true
 		},
-		"restore-cursor": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-			"integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-			"dev": true,
-			"requires": {
-				"onetime": "^5.1.0",
-				"signal-exit": "^3.0.2"
-			}
-		},
 		"ret": {
 			"version": "0.1.15",
 			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
 			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+			"dev": true
+		},
+		"reusify": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
 			"dev": true
 		},
 		"rimraf": {
@@ -7713,23 +8276,11 @@
 			"integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
 			"dev": true
 		},
-		"run-async": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-			"dev": true,
-			"requires": {
-				"is-promise": "^2.1.0"
-			}
-		},
-		"rxjs": {
-			"version": "6.5.4",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
-			"integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
-			"dev": true,
-			"requires": {
-				"tslib": "^1.9.0"
-			}
+		"run-parallel": {
+			"version": "1.1.9",
+			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+			"integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+			"dev": true
 		},
 		"safe-buffer": {
 			"version": "5.1.2",
@@ -7872,12 +8423,6 @@
 						"to-regex": "^3.0.2"
 					}
 				},
-				"minimist": {
-					"version": "1.2.5",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-					"dev": true
-				},
 				"normalize-path": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
@@ -7900,18 +8445,18 @@
 			}
 		},
 		"saxes": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.11.tgz",
-			"integrity": "sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+			"integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
 			"dev": true,
 			"requires": {
-				"xmlchars": "^2.1.1"
+				"xmlchars": "^2.2.0"
 			}
 		},
 		"semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"version": "7.3.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+			"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
 			"dev": true
 		},
 		"set-blocking": {
@@ -7944,18 +8489,18 @@
 			}
 		},
 		"shebang-command": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
 			"dev": true,
 			"requires": {
-				"shebang-regex": "^1.0.0"
+				"shebang-regex": "^3.0.0"
 			}
 		},
 		"shebang-regex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
 			"dev": true
 		},
 		"shellwords": {
@@ -7966,9 +8511,9 @@
 			"optional": true
 		},
 		"signal-exit": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
 			"dev": true
 		},
 		"sisteransi": {
@@ -8123,24 +8668,20 @@
 			}
 		},
 		"sort-array": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/sort-array/-/sort-array-2.0.0.tgz",
-			"integrity": "sha1-OKnG2if9fRR7QuYFVPKBGHtN9HI=",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/sort-array/-/sort-array-4.1.2.tgz",
+			"integrity": "sha512-G5IUpM+OcVnyaWHMv84Y/RQYiFQoSu6eUtJZu840iM6nR7zeY/eOGny2epkr5VKqCGDkOj3UBzOluDZ7hFpljA==",
 			"dev": true,
 			"requires": {
-				"array-back": "^1.0.4",
-				"object-get": "^2.1.0",
-				"typical": "^2.6.0"
+				"array-back": "^4.0.1",
+				"typical": "^6.0.1"
 			},
 			"dependencies": {
-				"array-back": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-					"integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
-					"dev": true,
-					"requires": {
-						"typical": "^2.6.0"
-					}
+				"typical": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/typical/-/typical-6.0.1.tgz",
+					"integrity": "sha512-+g3NEp7fJLe9DPa1TArHm9QAA7YciZmWnfAqEaFrBihQ7epOv9i99rjtgb6Iz0wh3WuQDjsCTDfgRoGnmHN81A==",
+					"dev": true
 				}
 			}
 		},
@@ -8164,9 +8705,9 @@
 			}
 		},
 		"source-map-support": {
-			"version": "0.5.16",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
-			"integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
+			"version": "0.5.19",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+			"integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
 			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
@@ -8180,9 +8721,9 @@
 			"dev": true
 		},
 		"spdx-correct": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
-			"integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+			"integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
 			"dev": true,
 			"requires": {
 				"spdx-expression-parse": "^3.0.0",
@@ -8190,15 +8731,15 @@
 			}
 		},
 		"spdx-exceptions": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-			"integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+			"integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
 			"dev": true
 		},
 		"spdx-expression-parse": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+			"integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
 			"dev": true,
 			"requires": {
 				"spdx-exceptions": "^2.1.0",
@@ -8206,9 +8747,9 @@
 			}
 		},
 		"spdx-license-ids": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-			"integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.6.tgz",
+			"integrity": "sha512-+orQK83kyMva3WyPf59k1+Y525csj5JejicWut55zeTWANuN17qSiSLUXWtzHeNWORSvT7GLDJ/E/XiIWoXBTw==",
 			"dev": true
 		},
 		"split-string": {
@@ -8244,10 +8785,21 @@
 			}
 		},
 		"stack-utils": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
-			"integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
-			"dev": true
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.2.tgz",
+			"integrity": "sha512-0H7QK2ECz3fyZMzQ8rH0j2ykpfbnd20BFtfg/SqVC2+sCTtcw0aDTGB7dk+de4U4uUeuz6nOtJcrkFFLG1B0Rg==",
+			"dev": true,
+			"requires": {
+				"escape-string-regexp": "^2.0.0"
+			},
+			"dependencies": {
+				"escape-string-regexp": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+					"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+					"dev": true
+				}
+			}
 		},
 		"static-extend": {
 			"version": "0.1.2",
@@ -8303,82 +8855,24 @@
 			"dev": true
 		},
 		"string-length": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/string-length/-/string-length-3.1.0.tgz",
-			"integrity": "sha512-Ttp5YvkGm5v9Ijagtaz1BnN+k9ObpvS0eIBblPMp2YWL8FBmi9qblQ9fexc2k/CXFgrTIteU3jAw3payCnwSTA==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.1.tgz",
+			"integrity": "sha512-PKyXUd0LK0ePjSOnWn34V2uD6acUWev9uy0Ft05k0E8xRW+SKcA0F7eMr7h5xlzfn+4O3N+55rduYyet3Jk+jw==",
 			"dev": true,
 			"requires": {
-				"astral-regex": "^1.0.0",
-				"strip-ansi": "^5.2.0"
+				"char-regex": "^1.0.2",
+				"strip-ansi": "^6.0.0"
 			}
 		},
 		"string-width": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-			"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+			"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
 			"dev": true,
 			"requires": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-					"dev": true
-				},
-				"emoji-regex": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-					"dev": true
-				},
-				"strip-ansi": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^5.0.0"
-					}
-				}
-			}
-		},
-		"string.prototype.trimleft": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
-			"integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.3",
-				"function-bind": "^1.1.1"
-			}
-		},
-		"string.prototype.trimright": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
-			"integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.3",
-				"function-bind": "^1.1.1"
-			}
-		},
-		"strip-ansi": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-			"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-			"dev": true,
-			"requires": {
-				"ansi-regex": "^4.1.0"
+				"emoji-regex": "^7.0.1",
+				"is-fullwidth-code-point": "^2.0.0",
+				"strip-ansi": "^5.1.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -8386,7 +8880,87 @@
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
 					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
 					"dev": true
+				},
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^4.1.0"
+					}
 				}
+			}
+		},
+		"string.prototype.trimend": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
+			"integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.5"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.17.7",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+					"integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+					"dev": true,
+					"requires": {
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1",
+						"is-callable": "^1.2.2",
+						"is-regex": "^1.1.1",
+						"object-inspect": "^1.8.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.1",
+						"string.prototype.trimend": "^1.0.1",
+						"string.prototype.trimstart": "^1.0.1"
+					}
+				}
+			}
+		},
+		"string.prototype.trimstart": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
+			"integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.5"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.17.7",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+					"integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+					"dev": true,
+					"requires": {
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1",
+						"is-callable": "^1.2.2",
+						"is-regex": "^1.1.1",
+						"object-inspect": "^1.8.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.1",
+						"string.prototype.trimend": "^1.0.1",
+						"string.prototype.trimstart": "^1.0.1"
+					}
+				}
+			}
+		},
+		"strip-ansi": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+			"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "^5.0.0"
 			}
 		},
 		"strip-bom": {
@@ -8408,9 +8982,9 @@
 			"dev": true
 		},
 		"strip-json-comments": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
-			"integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
 			"dev": true
 		},
 		"supports-color": {
@@ -8439,9 +9013,9 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -8465,19 +9039,6 @@
 				"lodash": "^4.17.14",
 				"slice-ansi": "^2.1.0",
 				"string-width": "^3.0.0"
-			},
-			"dependencies": {
-				"string-width": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^7.0.1",
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^5.1.0"
-					}
-				}
 			}
 		},
 		"table-layout": {
@@ -8570,21 +9131,6 @@
 			"integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
 			"dev": true
 		},
-		"through": {
-			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-			"dev": true
-		},
-		"tmp": {
-			"version": "0.0.33",
-			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-			"dev": true,
-			"requires": {
-				"os-tmpdir": "~1.0.2"
-			}
-		},
 		"tmpl": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
@@ -8650,18 +9196,30 @@
 			}
 		},
 		"tr46": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-2.0.2.tgz",
+			"integrity": "sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==",
 			"dev": true,
 			"requires": {
-				"punycode": "^2.1.0"
+				"punycode": "^2.1.1"
+			}
+		},
+		"tsconfig-paths": {
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
+			"integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
+			"dev": true,
+			"requires": {
+				"@types/json5": "^0.0.29",
+				"json5": "^1.0.1",
+				"minimist": "^1.2.0",
+				"strip-bom": "^3.0.0"
 			}
 		},
 		"tslib": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
-			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg==",
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+			"integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
 			"dev": true
 		},
 		"tsutils": {
@@ -8689,12 +9247,12 @@
 			"dev": true
 		},
 		"type-check": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+			"integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "~1.1.2"
+				"prelude-ls": "^1.2.1"
 			}
 		},
 		"type-detect": {
@@ -8731,14 +9289,11 @@
 			"dev": true
 		},
 		"uglify-js": {
-			"version": "3.9.4",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.9.4.tgz",
-			"integrity": "sha512-8RZBJq5smLOa7KslsNsVcSH+KOXf1uDU8yqLeNuVKwmT0T3FA0ZoXlinQfRad7SDcbZZRZE4ov+2v71EnxNyCA==",
+			"version": "3.11.0",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.11.0.tgz",
+			"integrity": "sha512-e1KQFRCpOxnrJsJVqDUCjURq+wXvIn7cK2sRAx9XL3HYLL9aezOP4Pb1+Y3/o693EPk111Yj2Q+IUXxcpHlygQ==",
 			"dev": true,
-			"optional": true,
-			"requires": {
-				"commander": "~2.20.3"
-			}
+			"optional": true
 		},
 		"underscore": {
 			"version": "1.10.2",
@@ -8820,21 +9375,22 @@
 			"dev": true
 		},
 		"uuid": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-			"integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
-			"dev": true
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
+			"integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==",
+			"dev": true,
+			"optional": true
 		},
 		"v8-compile-cache": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
-			"integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
+			"integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
 			"dev": true
 		},
 		"v8-to-istanbul": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-4.1.2.tgz",
-			"integrity": "sha512-G9R+Hpw0ITAmPSr47lSlc5A1uekSYzXxTMlFxso2xoffwo4jQnzbv1p9yXIinO8UMZKfAFewaCHwWvnH4Jb4Ug==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-5.0.1.tgz",
+			"integrity": "sha512-mbDNjuDajqYe3TXFk5qxcQy8L1msXNE37WTlLoqqpBfRsimbNcrlhQlDPntmECEcUvdC+AQ8CyMMf6EUx1r74Q==",
 			"dev": true,
 			"requires": {
 				"@types/istanbul-lib-coverage": "^2.0.1",
@@ -8881,13 +9437,11 @@
 			}
 		},
 		"w3c-xmlserializer": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-1.1.2.tgz",
-			"integrity": "sha512-p10l/ayESzrBMYWRID6xbuCKh2Fp77+sA0doRuGn4tTIMrrZVeqfpKjXHY+oDh3K4nLdPgNwMTVP6Vp4pvqbNg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
+			"integrity": "sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==",
 			"dev": true,
 			"requires": {
-				"domexception": "^1.0.1",
-				"webidl-conversions": "^4.0.2",
 				"xml-name-validator": "^3.0.0"
 			}
 		},
@@ -8907,9 +9461,9 @@
 			}
 		},
 		"webidl-conversions": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+			"integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
 			"dev": true
 		},
 		"whatwg-encoding": {
@@ -8928,20 +9482,20 @@
 			"dev": true
 		},
 		"whatwg-url": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-			"integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.3.0.tgz",
+			"integrity": "sha512-BQRf/ej5Rp3+n7k0grQXZj9a1cHtsp4lqj01p59xBWFKdezR8sO37XnpafwNqiFac/v2Il12EIMjX/Y4VZtT8Q==",
 			"dev": true,
 			"requires": {
 				"lodash.sortby": "^4.7.0",
-				"tr46": "^1.0.1",
-				"webidl-conversions": "^4.0.2"
+				"tr46": "^2.0.2",
+				"webidl-conversions": "^6.1.0"
 			}
 		},
 		"which": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
 			"dev": true,
 			"requires": {
 				"isexe": "^2.0.0"
@@ -9011,13 +9565,27 @@
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 					"dev": true
 				},
-				"strip-ansi": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^5.0.0"
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.0"
 					}
 				}
 			}
@@ -9050,9 +9618,9 @@
 			}
 		},
 		"ws": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
-			"integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ==",
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+			"integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
 			"dev": true
 		},
 		"xml-name-validator": {
@@ -9080,9 +9648,9 @@
 			"dev": true
 		},
 		"yargs": {
-			"version": "15.3.1",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
-			"integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
+			"version": "15.4.1",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+			"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
 			"dev": true,
 			"requires": {
 				"cliui": "^6.0.0",
@@ -9095,13 +9663,87 @@
 				"string-width": "^4.2.0",
 				"which-module": "^2.0.0",
 				"y18n": "^4.0.0",
-				"yargs-parser": "^18.1.1"
+				"yargs-parser": "^18.1.2"
+			},
+			"dependencies": {
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+					"dev": true
+				},
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.0"
+					}
+				}
 			}
 		},
 		"yargs-parser": {
-			"version": "18.1.2",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.2.tgz",
-			"integrity": "sha512-hlIPNR3IzC1YuL1c2UwwDKpXlNFBqD1Fswwh1khz5+d8Cq/8yc/Mn0i+rQXduu8hcrFKvO7Eryk+09NecTQAAQ==",
+			"version": "18.1.3",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+			"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
 			"dev": true,
 			"requires": {
 				"camelcase": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@trayio/connector-utils",
-	"version": "0.3.3",
+	"version": "0.3.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -14,19 +14,19 @@
 			}
 		},
 		"@babel/core": {
-			"version": "7.11.6",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.6.tgz",
-			"integrity": "sha512-Wpcv03AGnmkgm6uS6k8iwhIwTrcP0m17TL1n1sy7qD0qelDu4XNeW0dN0mHfa+Gei211yDaLoEe/VlbXQzM4Bg==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.1.tgz",
+			"integrity": "sha512-6bGmltqzIJrinwRRdczQsMhruSi9Sqty9Te+/5hudn4Izx/JYRhW1QELpR+CIL0gC/c9A7WroH6FmkDGxmWx3w==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.10.4",
-				"@babel/generator": "^7.11.6",
-				"@babel/helper-module-transforms": "^7.11.0",
-				"@babel/helpers": "^7.10.4",
-				"@babel/parser": "^7.11.5",
+				"@babel/generator": "^7.12.1",
+				"@babel/helper-module-transforms": "^7.12.1",
+				"@babel/helpers": "^7.12.1",
+				"@babel/parser": "^7.12.1",
 				"@babel/template": "^7.10.4",
-				"@babel/traverse": "^7.11.5",
-				"@babel/types": "^7.11.5",
+				"@babel/traverse": "^7.12.1",
+				"@babel/types": "^7.12.1",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.1",
@@ -37,6 +37,12 @@
 				"source-map": "^0.5.0"
 			},
 			"dependencies": {
+				"@babel/parser": {
+					"version": "7.12.2",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.2.tgz",
+					"integrity": "sha512-LMN+SqTiZEonUw4hQA0A3zG8DnN0E1F4K107LbDDUnC+0chML1rvWgsHloC9weB4RmZweE0uhFq0eGX7Nr/PBQ==",
+					"dev": true
+				},
 				"json5": {
 					"version": "2.1.3",
 					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
@@ -61,12 +67,12 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.11.6",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
-			"integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.1.tgz",
+			"integrity": "sha512-DB+6rafIdc9o72Yc3/Ph5h+6hUjeOp66pF0naQBgUFFuPqzQwIlPTm3xZR7YNvduIMtkDIj2t21LSQwnbCrXvg==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.11.5",
+				"@babel/types": "^7.12.1",
 				"jsesc": "^2.5.1",
 				"source-map": "^0.5.0"
 			},
@@ -100,35 +106,37 @@
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
-			"integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.1.tgz",
+			"integrity": "sha512-k0CIe3tXUKTRSoEx1LQEPFU9vRQfqHtl+kf8eNnDqb4AUJEy5pz6aIiog+YWtVm2jpggjS1laH68bPsR+KWWPQ==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.11.0"
+				"@babel/types": "^7.12.1"
 			}
 		},
 		"@babel/helper-module-imports": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
-			"integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.1.tgz",
+			"integrity": "sha512-ZeC1TlMSvikvJNy1v/wPIazCu3NdOwgYZLIkmIyAsGhqkNpiDoQQRmaCK8YP4Pq3GPTLPV9WXaPCJKvx06JxKA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.10.4"
+				"@babel/types": "^7.12.1"
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz",
-			"integrity": "sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz",
+			"integrity": "sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "^7.10.4",
-				"@babel/helper-replace-supers": "^7.10.4",
-				"@babel/helper-simple-access": "^7.10.4",
+				"@babel/helper-module-imports": "^7.12.1",
+				"@babel/helper-replace-supers": "^7.12.1",
+				"@babel/helper-simple-access": "^7.12.1",
 				"@babel/helper-split-export-declaration": "^7.11.0",
+				"@babel/helper-validator-identifier": "^7.10.4",
 				"@babel/template": "^7.10.4",
-				"@babel/types": "^7.11.0",
+				"@babel/traverse": "^7.12.1",
+				"@babel/types": "^7.12.1",
 				"lodash": "^4.17.19"
 			}
 		},
@@ -148,25 +156,24 @@
 			"dev": true
 		},
 		"@babel/helper-replace-supers": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
-			"integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.1.tgz",
+			"integrity": "sha512-zJjTvtNJnCFsCXVi5rUInstLd/EIVNmIKA1Q9ynESmMBWPWd+7sdR+G4/wdu+Mppfep0XLyG2m7EBPvjCeFyrw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-member-expression-to-functions": "^7.10.4",
+				"@babel/helper-member-expression-to-functions": "^7.12.1",
 				"@babel/helper-optimise-call-expression": "^7.10.4",
-				"@babel/traverse": "^7.10.4",
-				"@babel/types": "^7.10.4"
+				"@babel/traverse": "^7.12.1",
+				"@babel/types": "^7.12.1"
 			}
 		},
 		"@babel/helper-simple-access": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
-			"integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz",
+			"integrity": "sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.10.4",
-				"@babel/types": "^7.10.4"
+				"@babel/types": "^7.12.1"
 			}
 		},
 		"@babel/helper-split-export-declaration": {
@@ -185,14 +192,14 @@
 			"dev": true
 		},
 		"@babel/helpers": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.4.tgz",
-			"integrity": "sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.1.tgz",
+			"integrity": "sha512-9JoDSBGoWtmbay98efmT2+mySkwjzeFeAL9BuWNoVQpkPFQF8SIIFUfY5os9u8wVzglzoiPRSW7cuJmBDUt43g==",
 			"dev": true,
 			"requires": {
 				"@babel/template": "^7.10.4",
-				"@babel/traverse": "^7.10.4",
-				"@babel/types": "^7.10.4"
+				"@babel/traverse": "^7.12.1",
+				"@babel/types": "^7.12.1"
 			}
 		},
 		"@babel/highlight": {
@@ -231,9 +238,9 @@
 			}
 		},
 		"@babel/plugin-syntax-class-properties": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.10.4.tgz",
-			"integrity": "sha512-GCSBF7iUle6rNugfURwNmCGG3Z/2+opxAMLs1nND4bhEG5PuxTIggDBoeYYSujAlLtsupzOHYJQgPS3pivwXIA==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.1.tgz",
+			"integrity": "sha512-U40A76x5gTwmESz+qiqssqmeEsKvcSyvtgktrm0uzcARAmM9I1jR221f6Oq+GmHrcD+LvZDag1UTOTe2fL3TeA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4"
@@ -342,22 +349,28 @@
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.11.5",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
-			"integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.1.tgz",
+			"integrity": "sha512-MA3WPoRt1ZHo2ZmoGKNqi20YnPt0B1S0GTZEPhhd+hw2KGUzBlHuVunj6K4sNuK+reEvyiPwtp0cpaqLzJDmAw==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.10.4",
-				"@babel/generator": "^7.11.5",
+				"@babel/generator": "^7.12.1",
 				"@babel/helper-function-name": "^7.10.4",
 				"@babel/helper-split-export-declaration": "^7.11.0",
-				"@babel/parser": "^7.11.5",
-				"@babel/types": "^7.11.5",
+				"@babel/parser": "^7.12.1",
+				"@babel/types": "^7.12.1",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0",
 				"lodash": "^4.17.19"
 			},
 			"dependencies": {
+				"@babel/parser": {
+					"version": "7.12.2",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.2.tgz",
+					"integrity": "sha512-LMN+SqTiZEonUw4hQA0A3zG8DnN0E1F4K107LbDDUnC+0chML1rvWgsHloC9weB4RmZweE0uhFq0eGX7Nr/PBQ==",
+					"dev": true
+				},
 				"globals": {
 					"version": "11.12.0",
 					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -367,9 +380,9 @@
 			}
 		},
 		"@babel/types": {
-			"version": "7.11.5",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-			"integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.1.tgz",
+			"integrity": "sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-validator-identifier": "^7.10.4",
@@ -412,9 +425,9 @@
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "6.12.5",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
-					"integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
+					"version": "6.12.6",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+					"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 					"dev": true,
 					"requires": {
 						"fast-deep-equal": "^3.1.1",
@@ -508,23 +521,23 @@
 			"dev": true
 		},
 		"@jest/console": {
-			"version": "26.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/console/-/console-26.3.0.tgz",
-			"integrity": "sha512-/5Pn6sJev0nPUcAdpJHMVIsA8sKizL2ZkcKPE5+dJrCccks7tcM7c9wbgHudBJbxXLoTbqsHkG1Dofoem4F09w==",
+			"version": "26.5.2",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-26.5.2.tgz",
+			"integrity": "sha512-lJELzKINpF1v74DXHbCRIkQ/+nUV1M+ntj+X1J8LxCgpmJZjfLmhFejiMSbjjD66fayxl5Z06tbs3HMyuik6rw==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^26.3.0",
+				"@jest/types": "^26.5.2",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
-				"jest-message-util": "^26.3.0",
-				"jest-util": "^26.3.0",
+				"jest-message-util": "^26.5.2",
+				"jest-util": "^26.5.2",
 				"slash": "^3.0.0"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"version": "26.5.2",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -544,21 +557,20 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
-					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
+					"version": "15.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
+					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
 				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -605,34 +617,34 @@
 			}
 		},
 		"@jest/core": {
-			"version": "26.4.2",
-			"resolved": "https://registry.npmjs.org/@jest/core/-/core-26.4.2.tgz",
-			"integrity": "sha512-sDva7YkeNprxJfepOctzS8cAk9TOekldh+5FhVuXS40+94SHbiicRO1VV2tSoRtgIo+POs/Cdyf8p76vPTd6dg==",
+			"version": "26.5.3",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-26.5.3.tgz",
+			"integrity": "sha512-CiU0UKFF1V7KzYTVEtFbFmGLdb2g4aTtY0WlyUfLgj/RtoTnJFhh50xKKr7OYkdmBUlGFSa2mD1TU3UZ6OLd4g==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^26.3.0",
-				"@jest/reporters": "^26.4.1",
-				"@jest/test-result": "^26.3.0",
-				"@jest/transform": "^26.3.0",
-				"@jest/types": "^26.3.0",
+				"@jest/console": "^26.5.2",
+				"@jest/reporters": "^26.5.3",
+				"@jest/test-result": "^26.5.2",
+				"@jest/transform": "^26.5.2",
+				"@jest/types": "^26.5.2",
 				"@types/node": "*",
 				"ansi-escapes": "^4.2.1",
 				"chalk": "^4.0.0",
 				"exit": "^0.1.2",
 				"graceful-fs": "^4.2.4",
-				"jest-changed-files": "^26.3.0",
-				"jest-config": "^26.4.2",
-				"jest-haste-map": "^26.3.0",
-				"jest-message-util": "^26.3.0",
+				"jest-changed-files": "^26.5.2",
+				"jest-config": "^26.5.3",
+				"jest-haste-map": "^26.5.2",
+				"jest-message-util": "^26.5.2",
 				"jest-regex-util": "^26.0.0",
-				"jest-resolve": "^26.4.0",
-				"jest-resolve-dependencies": "^26.4.2",
-				"jest-runner": "^26.4.2",
-				"jest-runtime": "^26.4.2",
-				"jest-snapshot": "^26.4.2",
-				"jest-util": "^26.3.0",
-				"jest-validate": "^26.4.2",
-				"jest-watcher": "^26.3.0",
+				"jest-resolve": "^26.5.2",
+				"jest-resolve-dependencies": "^26.5.3",
+				"jest-runner": "^26.5.3",
+				"jest-runtime": "^26.5.3",
+				"jest-snapshot": "^26.5.3",
+				"jest-util": "^26.5.2",
+				"jest-validate": "^26.5.3",
+				"jest-watcher": "^26.5.2",
 				"micromatch": "^4.0.2",
 				"p-each-series": "^2.1.0",
 				"rimraf": "^3.0.0",
@@ -641,9 +653,9 @@
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"version": "26.5.2",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -663,21 +675,20 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
-					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
+					"version": "15.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
+					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
 				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -733,21 +744,21 @@
 			}
 		},
 		"@jest/environment": {
-			"version": "26.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.3.0.tgz",
-			"integrity": "sha512-EW+MFEo0DGHahf83RAaiqQx688qpXgl99wdb8Fy67ybyzHwR1a58LHcO376xQJHfmoXTu89M09dH3J509cx2AA==",
+			"version": "26.5.2",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.5.2.tgz",
+			"integrity": "sha512-YjhCD/Zhkz0/1vdlS/QN6QmuUdDkpgBdK4SdiVg4Y19e29g4VQYN5Xg8+YuHjdoWGY7wJHMxc79uDTeTOy9Ngw==",
 			"dev": true,
 			"requires": {
-				"@jest/fake-timers": "^26.3.0",
-				"@jest/types": "^26.3.0",
+				"@jest/fake-timers": "^26.5.2",
+				"@jest/types": "^26.5.2",
 				"@types/node": "*",
-				"jest-mock": "^26.3.0"
+				"jest-mock": "^26.5.2"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"version": "26.5.2",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -767,21 +778,20 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
-					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
+					"version": "15.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
+					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
 				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -828,23 +838,23 @@
 			}
 		},
 		"@jest/fake-timers": {
-			"version": "26.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.3.0.tgz",
-			"integrity": "sha512-ZL9ytUiRwVP8ujfRepffokBvD2KbxbqMhrXSBhSdAhISCw3gOkuntisiSFv+A6HN0n0fF4cxzICEKZENLmW+1A==",
+			"version": "26.5.2",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.5.2.tgz",
+			"integrity": "sha512-09Hn5Oraqt36V1akxQeWMVL0fR9c6PnEhpgLaYvREXZJAh2H2Y+QLCsl0g7uMoJeoWJAuz4tozk1prbR1Fc1sw==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^26.3.0",
+				"@jest/types": "^26.5.2",
 				"@sinonjs/fake-timers": "^6.0.1",
 				"@types/node": "*",
-				"jest-message-util": "^26.3.0",
-				"jest-mock": "^26.3.0",
-				"jest-util": "^26.3.0"
+				"jest-message-util": "^26.5.2",
+				"jest-mock": "^26.5.2",
+				"jest-util": "^26.5.2"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"version": "26.5.2",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -864,21 +874,20 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
-					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
+					"version": "15.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
+					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
 				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -925,20 +934,20 @@
 			}
 		},
 		"@jest/globals": {
-			"version": "26.4.2",
-			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.4.2.tgz",
-			"integrity": "sha512-Ot5ouAlehhHLRhc+sDz2/9bmNv9p5ZWZ9LE1pXGGTCXBasmi5jnYjlgYcYt03FBwLmZXCZ7GrL29c33/XRQiow==",
+			"version": "26.5.3",
+			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.5.3.tgz",
+			"integrity": "sha512-7QztI0JC2CuB+Wx1VdnOUNeIGm8+PIaqngYsZXQCkH2QV0GFqzAYc9BZfU0nuqA6cbYrWh5wkuMzyii3P7deug==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^26.3.0",
-				"@jest/types": "^26.3.0",
-				"expect": "^26.4.2"
+				"@jest/environment": "^26.5.2",
+				"@jest/types": "^26.5.2",
+				"expect": "^26.5.3"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"version": "26.5.2",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -958,21 +967,20 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
-					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
+					"version": "15.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
+					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
 				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -1019,16 +1027,16 @@
 			}
 		},
 		"@jest/reporters": {
-			"version": "26.4.1",
-			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.4.1.tgz",
-			"integrity": "sha512-aROTkCLU8++yiRGVxLsuDmZsQEKO6LprlrxtAuzvtpbIFl3eIjgIf3EUxDKgomkS25R9ZzwGEdB5weCcBZlrpQ==",
+			"version": "26.5.3",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.5.3.tgz",
+			"integrity": "sha512-X+vR0CpfMQzYcYmMFKNY9n4jklcb14Kffffp7+H/MqitWnb0440bW2L76NGWKAa+bnXhNoZr+lCVtdtPmfJVOQ==",
 			"dev": true,
 			"requires": {
 				"@bcoe/v8-coverage": "^0.2.3",
-				"@jest/console": "^26.3.0",
-				"@jest/test-result": "^26.3.0",
-				"@jest/transform": "^26.3.0",
-				"@jest/types": "^26.3.0",
+				"@jest/console": "^26.5.2",
+				"@jest/test-result": "^26.5.2",
+				"@jest/transform": "^26.5.2",
+				"@jest/types": "^26.5.2",
 				"chalk": "^4.0.0",
 				"collect-v8-coverage": "^1.0.0",
 				"exit": "^0.1.2",
@@ -1039,22 +1047,22 @@
 				"istanbul-lib-report": "^3.0.0",
 				"istanbul-lib-source-maps": "^4.0.0",
 				"istanbul-reports": "^3.0.2",
-				"jest-haste-map": "^26.3.0",
-				"jest-resolve": "^26.4.0",
-				"jest-util": "^26.3.0",
-				"jest-worker": "^26.3.0",
+				"jest-haste-map": "^26.5.2",
+				"jest-resolve": "^26.5.2",
+				"jest-util": "^26.5.2",
+				"jest-worker": "^26.5.0",
 				"node-notifier": "^8.0.0",
 				"slash": "^3.0.0",
 				"source-map": "^0.6.0",
 				"string-length": "^4.0.1",
 				"terminal-link": "^2.0.0",
-				"v8-to-istanbul": "^5.0.1"
+				"v8-to-istanbul": "^6.0.1"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"version": "26.5.2",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -1074,21 +1082,20 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
-					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
+					"version": "15.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
+					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
 				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -1135,9 +1142,9 @@
 			}
 		},
 		"@jest/source-map": {
-			"version": "26.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.3.0.tgz",
-			"integrity": "sha512-hWX5IHmMDWe1kyrKl7IhFwqOuAreIwHhbe44+XH2ZRHjrKIh0LO5eLQ/vxHFeAfRwJapmxuqlGAEYLadDq6ZGQ==",
+			"version": "26.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.5.0.tgz",
+			"integrity": "sha512-jWAw9ZwYHJMe9eZq/WrsHlwF8E3hM9gynlcDpOyCb9bR8wEd9ZNBZCi7/jZyzHxC7t3thZ10gO2IDhu0bPKS5g==",
 			"dev": true,
 			"requires": {
 				"callsites": "^3.0.0",
@@ -1146,21 +1153,21 @@
 			}
 		},
 		"@jest/test-result": {
-			"version": "26.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.3.0.tgz",
-			"integrity": "sha512-a8rbLqzW/q7HWheFVMtghXV79Xk+GWwOK1FrtimpI5n1la2SY0qHri3/b0/1F0Ve0/yJmV8pEhxDfVwiUBGtgg==",
+			"version": "26.5.2",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.5.2.tgz",
+			"integrity": "sha512-E/Zp6LURJEGSCWpoMGmCFuuEI1OWuI3hmZwmULV0GsgJBh7u0rwqioxhRU95euUuviqBDN8ruX/vP/4bwYolXw==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^26.3.0",
-				"@jest/types": "^26.3.0",
+				"@jest/console": "^26.5.2",
+				"@jest/types": "^26.5.2",
 				"@types/istanbul-lib-coverage": "^2.0.0",
 				"collect-v8-coverage": "^1.0.0"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"version": "26.5.2",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -1180,21 +1187,20 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
-					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
+					"version": "15.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
+					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
 				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -1241,34 +1247,34 @@
 			}
 		},
 		"@jest/test-sequencer": {
-			"version": "26.4.2",
-			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.4.2.tgz",
-			"integrity": "sha512-83DRD8N3M0tOhz9h0bn6Kl6dSp+US6DazuVF8J9m21WAp5x7CqSMaNycMP0aemC/SH/pDQQddbsfHRTBXVUgog==",
+			"version": "26.5.3",
+			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.5.3.tgz",
+			"integrity": "sha512-Wqzb7aQ13L3T47xHdpUqYMOpiqz6Dx2QDDghp5AV/eUDXR7JieY+E1s233TQlNyl+PqtqgjVokmyjzX/HA51BA==",
 			"dev": true,
 			"requires": {
-				"@jest/test-result": "^26.3.0",
+				"@jest/test-result": "^26.5.2",
 				"graceful-fs": "^4.2.4",
-				"jest-haste-map": "^26.3.0",
-				"jest-runner": "^26.4.2",
-				"jest-runtime": "^26.4.2"
+				"jest-haste-map": "^26.5.2",
+				"jest-runner": "^26.5.3",
+				"jest-runtime": "^26.5.3"
 			}
 		},
 		"@jest/transform": {
-			"version": "26.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.3.0.tgz",
-			"integrity": "sha512-Isj6NB68QorGoFWvcOjlUhpkT56PqNIsXKR7XfvoDlCANn/IANlh8DrKAA2l2JKC3yWSMH5wS0GwuQM20w3b2A==",
+			"version": "26.5.2",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.5.2.tgz",
+			"integrity": "sha512-AUNjvexh+APhhmS8S+KboPz+D3pCxPvEAGduffaAJYxIFxGi/ytZQkrqcKDUU0ERBAo5R7087fyOYr2oms1seg==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.1.0",
-				"@jest/types": "^26.3.0",
+				"@jest/types": "^26.5.2",
 				"babel-plugin-istanbul": "^6.0.0",
 				"chalk": "^4.0.0",
 				"convert-source-map": "^1.4.0",
 				"fast-json-stable-stringify": "^2.0.0",
 				"graceful-fs": "^4.2.4",
-				"jest-haste-map": "^26.3.0",
+				"jest-haste-map": "^26.5.2",
 				"jest-regex-util": "^26.0.0",
-				"jest-util": "^26.3.0",
+				"jest-util": "^26.5.2",
 				"micromatch": "^4.0.2",
 				"pirates": "^4.0.1",
 				"slash": "^3.0.0",
@@ -1277,9 +1283,9 @@
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"version": "26.5.2",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -1299,21 +1305,20 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
-					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
+					"version": "15.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
+					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
 				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -1455,12 +1460,6 @@
 				"@babel/types": "^7.3.0"
 			}
 		},
-		"@types/color-name": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
-			"dev": true
-		},
 		"@types/graceful-fs": {
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.3.tgz",
@@ -1508,9 +1507,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "14.11.2",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
-			"integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA==",
+			"version": "14.11.8",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.8.tgz",
+			"integrity": "sha512-KPcKqKm5UKDkaYPTuXSx8wEP7vE9GnuaXIZKijwRYcePpZFDVuy2a57LarFKiORbHOuTOOwYzxVxcUzsh2P2Pw==",
 			"dev": true
 		},
 		"@types/normalize-package-data": {
@@ -1520,15 +1519,15 @@
 			"dev": true
 		},
 		"@types/prettier": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.1.tgz",
-			"integrity": "sha512-2zs+O+UkDsJ1Vcp667pd3f8xearMdopz/z54i99wtRDI5KLmngk7vlrYZD0ZjKHaROR03EznlBbVY9PfAEyJIQ==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.2.tgz",
+			"integrity": "sha512-IiPhNnenzkqdSdQH3ifk9LoX7oQe61ZlDdDO4+MUv6FyWdPGDPr26gCPVs3oguZEMq//nFZZpwUZcVuNJsG+DQ==",
 			"dev": true
 		},
 		"@types/stack-utils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
-			"integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
+			"integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
 			"dev": true
 		},
 		"@types/yargs": {
@@ -1547,43 +1546,43 @@
 			"dev": true
 		},
 		"@typescript-eslint/experimental-utils": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.3.0.tgz",
-			"integrity": "sha512-cmmIK8shn3mxmhpKfzMMywqiEheyfXLV/+yPDnOTvQX/ztngx7Lg/OD26J8gTZfkLKUmaEBxO2jYP3keV7h2OQ==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.4.1.tgz",
+			"integrity": "sha512-Nt4EVlb1mqExW9cWhpV6pd1a3DkUbX9DeyYsdoeziKOpIJ04S2KMVDO+SEidsXRH/XHDpbzXykKcMTLdTXH6cQ==",
 			"dev": true,
 			"requires": {
 				"@types/json-schema": "^7.0.3",
-				"@typescript-eslint/scope-manager": "4.3.0",
-				"@typescript-eslint/types": "4.3.0",
-				"@typescript-eslint/typescript-estree": "4.3.0",
+				"@typescript-eslint/scope-manager": "4.4.1",
+				"@typescript-eslint/types": "4.4.1",
+				"@typescript-eslint/typescript-estree": "4.4.1",
 				"eslint-scope": "^5.0.0",
 				"eslint-utils": "^2.0.0"
 			}
 		},
 		"@typescript-eslint/scope-manager": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.3.0.tgz",
-			"integrity": "sha512-cTeyP5SCNE8QBRfc+Lgh4Xpzje46kNUhXYfc3pQWmJif92sjrFuHT9hH4rtOkDTo/si9Klw53yIr+djqGZS1ig==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.4.1.tgz",
+			"integrity": "sha512-2oD/ZqD4Gj41UdFeWZxegH3cVEEH/Z6Bhr/XvwTtGv66737XkR4C9IqEkebCuqArqBJQSj4AgNHHiN1okzD/wQ==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "4.3.0",
-				"@typescript-eslint/visitor-keys": "4.3.0"
+				"@typescript-eslint/types": "4.4.1",
+				"@typescript-eslint/visitor-keys": "4.4.1"
 			}
 		},
 		"@typescript-eslint/types": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.3.0.tgz",
-			"integrity": "sha512-Cx9TpRvlRjOppGsU6Y6KcJnUDOelja2NNCX6AZwtVHRzaJkdytJWMuYiqi8mS35MRNA3cJSwDzXePfmhU6TANw==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.4.1.tgz",
+			"integrity": "sha512-KNDfH2bCyax5db+KKIZT4rfA8rEk5N0EJ8P0T5AJjo5xrV26UAzaiqoJCxeaibqc0c/IvZxp7v2g3difn2Pn3w==",
 			"dev": true
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.3.0.tgz",
-			"integrity": "sha512-ZAI7xjkl+oFdLV/COEz2tAbQbR3XfgqHEGy0rlUXzfGQic6EBCR4s2+WS3cmTPG69aaZckEucBoTxW9PhzHxxw==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.4.1.tgz",
+			"integrity": "sha512-wP/V7ScKzgSdtcY1a0pZYBoCxrCstLrgRQ2O9MmCUZDtmgxCO/TCqOTGRVwpP4/2hVfqMz/Vw1ZYrG8cVxvN3g==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "4.3.0",
-				"@typescript-eslint/visitor-keys": "4.3.0",
+				"@typescript-eslint/types": "4.4.1",
+				"@typescript-eslint/visitor-keys": "4.4.1",
 				"debug": "^4.1.1",
 				"globby": "^11.0.1",
 				"is-glob": "^4.0.1",
@@ -1593,21 +1592,13 @@
 			}
 		},
 		"@typescript-eslint/visitor-keys": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.3.0.tgz",
-			"integrity": "sha512-xZxkuR7XLM6RhvLkgv9yYlTcBHnTULzfnw4i6+z2TGBLy9yljAypQaZl9c3zFvy7PNI7fYWyvKYtohyF8au3cw==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.4.1.tgz",
+			"integrity": "sha512-H2JMWhLaJNeaylSnMSQFEhT/S/FsJbebQALmoJxMPMxLtlVAMy2uJP/Z543n9IizhjRayLSqoInehCeNW9rWcw==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "4.3.0",
+				"@typescript-eslint/types": "4.4.1",
 				"eslint-visitor-keys": "^2.0.0"
-			},
-			"dependencies": {
-				"eslint-visitor-keys": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
-					"integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
-					"dev": true
-				}
 			}
 		},
 		"abab": {
@@ -1617,9 +1608,9 @@
 			"dev": true
 		},
 		"acorn": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
-			"integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
+			"version": "7.4.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+			"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
 			"dev": true
 		},
 		"acorn-globals": {
@@ -1909,25 +1900,25 @@
 			"dev": true
 		},
 		"babel-jest": {
-			"version": "26.3.0",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.3.0.tgz",
-			"integrity": "sha512-sxPnQGEyHAOPF8NcUsD0g7hDCnvLL2XyblRBcgrzTWBB/mAIpWow3n1bEL+VghnnZfreLhFSBsFluRoK2tRK4g==",
+			"version": "26.5.2",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.5.2.tgz",
+			"integrity": "sha512-U3KvymF3SczA3vOL/cgiUFOznfMET+XDIXiWnoJV45siAp2pLMG8i2+/MGZlAC3f/F6Q40LR4M4qDrWZ9wkK8A==",
 			"dev": true,
 			"requires": {
-				"@jest/transform": "^26.3.0",
-				"@jest/types": "^26.3.0",
+				"@jest/transform": "^26.5.2",
+				"@jest/types": "^26.5.2",
 				"@types/babel__core": "^7.1.7",
 				"babel-plugin-istanbul": "^6.0.0",
-				"babel-preset-jest": "^26.3.0",
+				"babel-preset-jest": "^26.5.0",
 				"chalk": "^4.0.0",
 				"graceful-fs": "^4.2.4",
 				"slash": "^3.0.0"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"version": "26.5.2",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -1947,21 +1938,20 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
-					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
+					"version": "15.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
+					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
 				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -2021,9 +2011,9 @@
 			}
 		},
 		"babel-plugin-jest-hoist": {
-			"version": "26.2.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.2.0.tgz",
-			"integrity": "sha512-B/hVMRv8Nh1sQ1a3EY8I0n4Y1Wty3NrR5ebOyVT302op+DOAau+xNEImGMsUWOC3++ZlMooCytKz+NgN8aKGbA==",
+			"version": "26.5.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.5.0.tgz",
+			"integrity": "sha512-ck17uZFD3CDfuwCLATWZxkkuGGFhMij8quP8CNhwj8ek1mqFgbFzRJ30xwC04LLscj/aKsVFfRST+b5PT7rSuw==",
 			"dev": true,
 			"requires": {
 				"@babel/template": "^7.3.3",
@@ -2033,9 +2023,9 @@
 			}
 		},
 		"babel-preset-current-node-syntax": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.3.tgz",
-			"integrity": "sha512-uyexu1sVwcdFnyq9o8UQYsXwXflIh8LvrF5+cKrYam93ned1CStffB3+BEcsxGSgagoA3GEyjDqO4a/58hyPYQ==",
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.4.tgz",
+			"integrity": "sha512-5/INNCYhUGqw7VbVjT/hb3ucjgkVHKXY7lX3ZjlN4gm565VyFmJUrJ/h+h16ECVB38R/9SF6aACydpKMLZ/c9w==",
 			"dev": true,
 			"requires": {
 				"@babel/plugin-syntax-async-generators": "^7.8.4",
@@ -2052,12 +2042,12 @@
 			}
 		},
 		"babel-preset-jest": {
-			"version": "26.3.0",
-			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.3.0.tgz",
-			"integrity": "sha512-5WPdf7nyYi2/eRxCbVrE1kKCWxgWY4RsPEbdJWFm7QsesFGqjdkyLeu1zRkwM1cxK6EPIlNd6d2AxLk7J+t4pw==",
+			"version": "26.5.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.5.0.tgz",
+			"integrity": "sha512-F2vTluljhqkiGSJGBg/jOruA8vIIIL11YrxRcO7nviNTMbbofPSHwnm8mgP7d/wS7wRSexRoI6X1A6T74d4LQA==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-jest-hoist": "^26.2.0",
+				"babel-plugin-jest-hoist": "^26.5.0",
 				"babel-preset-current-node-syntax": "^0.1.3"
 			}
 		},
@@ -2925,9 +2915,9 @@
 			}
 		},
 		"eslint": {
-			"version": "7.10.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.10.0.tgz",
-			"integrity": "sha512-BDVffmqWl7JJXqCjAK6lWtcQThZB/aP1HXSH1JKwGwv0LQEdvpR7qzNrUT487RM39B5goWuboFad5ovMBmD8yA==",
+			"version": "7.11.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.11.0.tgz",
+			"integrity": "sha512-G9+qtYVCHaDi1ZuWzBsOWo2wSwd70TXnU6UHA3cTYHp7gCTXZcpggWFoUVAMRarg68qtPoNfFbzPh+VdOgmwmw==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
@@ -2940,7 +2930,7 @@
 				"enquirer": "^2.3.5",
 				"eslint-scope": "^5.1.1",
 				"eslint-utils": "^2.1.0",
-				"eslint-visitor-keys": "^1.3.0",
+				"eslint-visitor-keys": "^2.0.0",
 				"espree": "^7.3.0",
 				"esquery": "^1.2.0",
 				"esutils": "^2.0.2",
@@ -2970,12 +2960,11 @@
 			},
 			"dependencies": {
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -3144,9 +3133,9 @@
 			}
 		},
 		"eslint-plugin-jest": {
-			"version": "24.0.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.0.2.tgz",
-			"integrity": "sha512-DSBLNpkKDOpUJQkTGSs5sVJWsu0nDyQ2rYxkr0Eh7nrkc5bMUr/dlDbtTj3l8y6UaCVsem6rryF1OZrKnz1S5g==",
+			"version": "24.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.1.0.tgz",
+			"integrity": "sha512-827YJ+E8B9PvXu/0eiVSNFfxxndbKv+qE/3GSMhdorCaeaOehtqHGX2YDW9B85TEOre9n/zscledkFW/KbnyGg==",
 			"dev": true,
 			"requires": {
 				"@typescript-eslint/experimental-utils": "^4.0.1"
@@ -3211,12 +3200,20 @@
 			"dev": true,
 			"requires": {
 				"eslint-visitor-keys": "^1.1.0"
+			},
+			"dependencies": {
+				"eslint-visitor-keys": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+					"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+					"dev": true
+				}
 			}
 		},
 		"eslint-visitor-keys": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-			"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
+			"integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
 			"dev": true
 		},
 		"espree": {
@@ -3228,6 +3225,14 @@
 				"acorn": "^7.4.0",
 				"acorn-jsx": "^5.2.0",
 				"eslint-visitor-keys": "^1.3.0"
+			},
+			"dependencies": {
+				"eslint-visitor-keys": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+					"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+					"dev": true
+				}
 			}
 		},
 		"esprima": {
@@ -3411,23 +3416,23 @@
 			}
 		},
 		"expect": {
-			"version": "26.4.2",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-26.4.2.tgz",
-			"integrity": "sha512-IlJ3X52Z0lDHm7gjEp+m76uX46ldH5VpqmU0006vqDju/285twh7zaWMRhs67VpQhBwjjMchk+p5aA0VkERCAA==",
+			"version": "26.5.3",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-26.5.3.tgz",
+			"integrity": "sha512-kkpOhGRWGOr+TEFUnYAjfGvv35bfP+OlPtqPIJpOCR9DVtv8QV+p8zG0Edqafh80fsjeE+7RBcVUq1xApnYglw==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^26.3.0",
+				"@jest/types": "^26.5.2",
 				"ansi-styles": "^4.0.0",
 				"jest-get-type": "^26.3.0",
-				"jest-matcher-utils": "^26.4.2",
-				"jest-message-util": "^26.3.0",
+				"jest-matcher-utils": "^26.5.2",
+				"jest-message-util": "^26.5.2",
 				"jest-regex-util": "^26.0.0"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"version": "26.5.2",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -3447,21 +3452,20 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
-					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
+					"version": "15.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
+					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
 				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -3491,9 +3495,9 @@
 					"dev": true
 				},
 				"diff-sequences": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.3.0.tgz",
-					"integrity": "sha512-5j5vdRcw3CNctePNYN0Wy2e/JbWT6cAYnXv5OuqPhDpyCGc0uLu2TK0zOCJWNB9kOIfYMSpIulRaDgIi4HJ6Ig==",
+					"version": "26.5.0",
+					"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.5.0.tgz",
+					"integrity": "sha512-ZXx86srb/iYy6jG71k++wBN9P9J05UNQ5hQHQd9MtMPvcqXPx/vKU69jfHV637D00Q2gSgPk2D+jSx3l1lDW/Q==",
 					"dev": true
 				},
 				"has-flag": {
@@ -3503,15 +3507,15 @@
 					"dev": true
 				},
 				"jest-diff": {
-					"version": "26.4.2",
-					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.4.2.tgz",
-					"integrity": "sha512-6T1XQY8U28WH0Z5rGpQ+VqZSZz8EN8rZcBtfvXaOkbwxIEeRre6qnuZQlbY1AJ4MKDxQF8EkrCvK+hL/VkyYLQ==",
+					"version": "26.5.2",
+					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.5.2.tgz",
+					"integrity": "sha512-HCSWDUGwsov5oTlGzrRM+UPJI/Dpqi9jzeV0fdRNi3Ch5bnoXhnyJMmVg2juv9081zLIy3HGPI5mcuGgXM2xRA==",
 					"dev": true,
 					"requires": {
 						"chalk": "^4.0.0",
-						"diff-sequences": "^26.3.0",
+						"diff-sequences": "^26.5.0",
 						"jest-get-type": "^26.3.0",
-						"pretty-format": "^26.4.2"
+						"pretty-format": "^26.5.2"
 					}
 				},
 				"jest-get-type": {
@@ -3521,24 +3525,24 @@
 					"dev": true
 				},
 				"jest-matcher-utils": {
-					"version": "26.4.2",
-					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.4.2.tgz",
-					"integrity": "sha512-KcbNqWfWUG24R7tu9WcAOKKdiXiXCbMvQYT6iodZ9k1f7065k0keUOW6XpJMMvah+hTfqkhJhRXmA3r3zMAg0Q==",
+					"version": "26.5.2",
+					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.5.2.tgz",
+					"integrity": "sha512-W9GO9KBIC4gIArsNqDUKsLnhivaqf8MSs6ujO/JDcPIQrmY+aasewweXVET8KdrJ6ADQaUne5UzysvF/RR7JYA==",
 					"dev": true,
 					"requires": {
 						"chalk": "^4.0.0",
-						"jest-diff": "^26.4.2",
+						"jest-diff": "^26.5.2",
 						"jest-get-type": "^26.3.0",
-						"pretty-format": "^26.4.2"
+						"pretty-format": "^26.5.2"
 					}
 				},
 				"pretty-format": {
-					"version": "26.4.2",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
-					"integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
+					"version": "26.5.2",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.2.tgz",
+					"integrity": "sha512-VizyV669eqESlkOikKJI8Ryxl/kPpbdLwNdPs2GrbQs18MpySB5S0Yo0N7zkg2xTRiFq4CFw8ct5Vg4a0xP0og==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^26.3.0",
+						"@jest/types": "^26.5.2",
 						"ansi-regex": "^5.0.0",
 						"ansi-styles": "^4.0.0",
 						"react-is": "^16.12.0"
@@ -3994,9 +3998,9 @@
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "6.12.5",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
-					"integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
+					"version": "6.12.6",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+					"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 					"dev": true,
 					"requires": {
 						"fast-deep-equal": "^3.1.1",
@@ -4558,20 +4562,20 @@
 			}
 		},
 		"jest": {
-			"version": "26.4.2",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-26.4.2.tgz",
-			"integrity": "sha512-LLCjPrUh98Ik8CzW8LLVnSCfLaiY+wbK53U7VxnFSX7Q+kWC4noVeDvGWIFw0Amfq1lq2VfGm7YHWSLBV62MJw==",
+			"version": "26.5.3",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-26.5.3.tgz",
+			"integrity": "sha512-uJi3FuVSLmkZrWvaDyaVTZGLL8WcfynbRnFXyAHuEtYiSZ+ijDDIMOw1ytmftK+y/+OdAtsG9QrtbF7WIBmOyA==",
 			"dev": true,
 			"requires": {
-				"@jest/core": "^26.4.2",
+				"@jest/core": "^26.5.3",
 				"import-local": "^3.0.2",
-				"jest-cli": "^26.4.2"
+				"jest-cli": "^26.5.3"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"version": "26.5.2",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -4591,21 +4595,20 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
-					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
+					"version": "15.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
+					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
 				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -4641,24 +4644,24 @@
 					"dev": true
 				},
 				"jest-cli": {
-					"version": "26.4.2",
-					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.4.2.tgz",
-					"integrity": "sha512-zb+lGd/SfrPvoRSC/0LWdaWCnscXc1mGYW//NP4/tmBvRPT3VntZ2jtKUONsRi59zc5JqmsSajA9ewJKFYp8Cw==",
+					"version": "26.5.3",
+					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.5.3.tgz",
+					"integrity": "sha512-HkbSvtugpSXBf2660v9FrNVUgxvPkssN8CRGj9gPM8PLhnaa6zziFiCEKQAkQS4uRzseww45o0TR+l6KeRYV9A==",
 					"dev": true,
 					"requires": {
-						"@jest/core": "^26.4.2",
-						"@jest/test-result": "^26.3.0",
-						"@jest/types": "^26.3.0",
+						"@jest/core": "^26.5.3",
+						"@jest/test-result": "^26.5.2",
+						"@jest/types": "^26.5.2",
 						"chalk": "^4.0.0",
 						"exit": "^0.1.2",
 						"graceful-fs": "^4.2.4",
 						"import-local": "^3.0.2",
 						"is-ci": "^2.0.0",
-						"jest-config": "^26.4.2",
-						"jest-util": "^26.3.0",
-						"jest-validate": "^26.4.2",
+						"jest-config": "^26.5.3",
+						"jest-util": "^26.5.2",
+						"jest-validate": "^26.5.3",
 						"prompts": "^2.0.1",
-						"yargs": "^15.3.1"
+						"yargs": "^15.4.1"
 					}
 				},
 				"supports-color": {
@@ -4673,20 +4676,20 @@
 			}
 		},
 		"jest-changed-files": {
-			"version": "26.3.0",
-			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.3.0.tgz",
-			"integrity": "sha512-1C4R4nijgPltX6fugKxM4oQ18zimS7LqQ+zTTY8lMCMFPrxqBFb7KJH0Z2fRQJvw2Slbaipsqq7s1mgX5Iot+g==",
+			"version": "26.5.2",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.5.2.tgz",
+			"integrity": "sha512-qSmssmiIdvM5BWVtyK/nqVpN3spR5YyvkvPqz1x3BR1bwIxsWmU/MGwLoCrPNLbkG2ASAKfvmJpOduEApBPh2w==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^26.3.0",
+				"@jest/types": "^26.5.2",
 				"execa": "^4.0.0",
 				"throat": "^5.0.0"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"version": "26.5.2",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -4706,21 +4709,20 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
-					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
+					"version": "15.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
+					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
 				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -4808,35 +4810,35 @@
 			}
 		},
 		"jest-config": {
-			"version": "26.4.2",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.4.2.tgz",
-			"integrity": "sha512-QBf7YGLuToiM8PmTnJEdRxyYy3mHWLh24LJZKVdXZ2PNdizSe1B/E8bVm+HYcjbEzGuVXDv/di+EzdO/6Gq80A==",
+			"version": "26.5.3",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.5.3.tgz",
+			"integrity": "sha512-NVhZiIuN0GQM6b6as4CI5FSCyXKxdrx5ACMCcv/7Pf+TeCajJhJc+6dwgdAVPyerUFB9pRBIz3bE7clSrRge/w==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.1.0",
-				"@jest/test-sequencer": "^26.4.2",
-				"@jest/types": "^26.3.0",
-				"babel-jest": "^26.3.0",
+				"@jest/test-sequencer": "^26.5.3",
+				"@jest/types": "^26.5.2",
+				"babel-jest": "^26.5.2",
 				"chalk": "^4.0.0",
 				"deepmerge": "^4.2.2",
 				"glob": "^7.1.1",
 				"graceful-fs": "^4.2.4",
-				"jest-environment-jsdom": "^26.3.0",
-				"jest-environment-node": "^26.3.0",
+				"jest-environment-jsdom": "^26.5.2",
+				"jest-environment-node": "^26.5.2",
 				"jest-get-type": "^26.3.0",
-				"jest-jasmine2": "^26.4.2",
+				"jest-jasmine2": "^26.5.3",
 				"jest-regex-util": "^26.0.0",
-				"jest-resolve": "^26.4.0",
-				"jest-util": "^26.3.0",
-				"jest-validate": "^26.4.2",
+				"jest-resolve": "^26.5.2",
+				"jest-util": "^26.5.2",
+				"jest-validate": "^26.5.3",
 				"micromatch": "^4.0.2",
-				"pretty-format": "^26.4.2"
+				"pretty-format": "^26.5.2"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"version": "26.5.2",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -4856,21 +4858,20 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
-					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
+					"version": "15.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
+					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
 				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -4912,12 +4913,12 @@
 					"dev": true
 				},
 				"pretty-format": {
-					"version": "26.4.2",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
-					"integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
+					"version": "26.5.2",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.2.tgz",
+					"integrity": "sha512-VizyV669eqESlkOikKJI8Ryxl/kPpbdLwNdPs2GrbQs18MpySB5S0Yo0N7zkg2xTRiFq4CFw8ct5Vg4a0xP0og==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^26.3.0",
+						"@jest/types": "^26.5.2",
 						"ansi-regex": "^5.0.0",
 						"ansi-styles": "^4.0.0",
 						"react-is": "^16.12.0"
@@ -4962,22 +4963,22 @@
 			}
 		},
 		"jest-each": {
-			"version": "26.4.2",
-			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.4.2.tgz",
-			"integrity": "sha512-p15rt8r8cUcRY0Mvo1fpkOGYm7iI8S6ySxgIdfh3oOIv+gHwrHTy5VWCGOecWUhDsit4Nz8avJWdT07WLpbwDA==",
+			"version": "26.5.2",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.5.2.tgz",
+			"integrity": "sha512-w7D9FNe0m2D3yZ0Drj9CLkyF/mGhmBSULMQTypzAKR746xXnjUrK8GUJdlLTWUF6dd0ks3MtvGP7/xNFr9Aphg==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^26.3.0",
+				"@jest/types": "^26.5.2",
 				"chalk": "^4.0.0",
 				"jest-get-type": "^26.3.0",
-				"jest-util": "^26.3.0",
-				"pretty-format": "^26.4.2"
+				"jest-util": "^26.5.2",
+				"pretty-format": "^26.5.2"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"version": "26.5.2",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -4997,21 +4998,20 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
-					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
+					"version": "15.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
+					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
 				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -5053,12 +5053,12 @@
 					"dev": true
 				},
 				"pretty-format": {
-					"version": "26.4.2",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
-					"integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
+					"version": "26.5.2",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.2.tgz",
+					"integrity": "sha512-VizyV669eqESlkOikKJI8Ryxl/kPpbdLwNdPs2GrbQs18MpySB5S0Yo0N7zkg2xTRiFq4CFw8ct5Vg4a0xP0og==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^26.3.0",
+						"@jest/types": "^26.5.2",
 						"ansi-regex": "^5.0.0",
 						"ansi-styles": "^4.0.0",
 						"react-is": "^16.12.0"
@@ -5082,24 +5082,24 @@
 			}
 		},
 		"jest-environment-jsdom": {
-			"version": "26.3.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.3.0.tgz",
-			"integrity": "sha512-zra8He2btIMJkAzvLaiZ9QwEPGEetbxqmjEBQwhH3CA+Hhhu0jSiEJxnJMbX28TGUvPLxBt/zyaTLrOPF4yMJA==",
+			"version": "26.5.2",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.5.2.tgz",
+			"integrity": "sha512-fWZPx0bluJaTQ36+PmRpvUtUlUFlGGBNyGX1SN3dLUHHMcQ4WseNEzcGGKOw4U5towXgxI4qDoI3vwR18H0RTw==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^26.3.0",
-				"@jest/fake-timers": "^26.3.0",
-				"@jest/types": "^26.3.0",
+				"@jest/environment": "^26.5.2",
+				"@jest/fake-timers": "^26.5.2",
+				"@jest/types": "^26.5.2",
 				"@types/node": "*",
-				"jest-mock": "^26.3.0",
-				"jest-util": "^26.3.0",
-				"jsdom": "^16.2.2"
+				"jest-mock": "^26.5.2",
+				"jest-util": "^26.5.2",
+				"jsdom": "^16.4.0"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"version": "26.5.2",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -5119,21 +5119,20 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
-					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
+					"version": "15.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
+					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
 				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -5180,23 +5179,23 @@
 			}
 		},
 		"jest-environment-node": {
-			"version": "26.3.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.3.0.tgz",
-			"integrity": "sha512-c9BvYoo+FGcMj5FunbBgtBnbR5qk3uky8PKyRVpSfe2/8+LrNQMiXX53z6q2kY+j15SkjQCOSL/6LHnCPLVHNw==",
+			"version": "26.5.2",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.5.2.tgz",
+			"integrity": "sha512-YHjnDsf/GKFCYMGF1V+6HF7jhY1fcLfLNBDjhAOvFGvt6d8vXvNdJGVM7uTZ2VO/TuIyEFhPGaXMX5j3h7fsrA==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^26.3.0",
-				"@jest/fake-timers": "^26.3.0",
-				"@jest/types": "^26.3.0",
+				"@jest/environment": "^26.5.2",
+				"@jest/fake-timers": "^26.5.2",
+				"@jest/types": "^26.5.2",
 				"@types/node": "*",
-				"jest-mock": "^26.3.0",
-				"jest-util": "^26.3.0"
+				"jest-mock": "^26.5.2",
+				"jest-util": "^26.5.2"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"version": "26.5.2",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -5216,21 +5215,20 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
-					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
+					"version": "15.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
+					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
 				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -5283,12 +5281,12 @@
 			"dev": true
 		},
 		"jest-haste-map": {
-			"version": "26.3.0",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.3.0.tgz",
-			"integrity": "sha512-DHWBpTJgJhLLGwE5Z1ZaqLTYqeODQIZpby0zMBsCU9iRFHYyhklYqP4EiG73j5dkbaAdSZhgB938mL51Q5LeZA==",
+			"version": "26.5.2",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.5.2.tgz",
+			"integrity": "sha512-lJIAVJN3gtO3k4xy+7i2Xjtwh8CfPcH08WYjZpe9xzveDaqGw9fVNCpkYu6M525wKFVkLmyi7ku+DxCAP1lyMA==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^26.3.0",
+				"@jest/types": "^26.5.2",
 				"@types/graceful-fs": "^4.1.2",
 				"@types/node": "*",
 				"anymatch": "^3.0.3",
@@ -5296,18 +5294,18 @@
 				"fsevents": "^2.1.2",
 				"graceful-fs": "^4.2.4",
 				"jest-regex-util": "^26.0.0",
-				"jest-serializer": "^26.3.0",
-				"jest-util": "^26.3.0",
-				"jest-worker": "^26.3.0",
+				"jest-serializer": "^26.5.0",
+				"jest-util": "^26.5.2",
+				"jest-worker": "^26.5.0",
 				"micromatch": "^4.0.2",
 				"sane": "^4.0.3",
 				"walker": "^1.0.7"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"version": "26.5.2",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -5327,21 +5325,20 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
-					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
+					"version": "15.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
+					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
 				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -5388,35 +5385,35 @@
 			}
 		},
 		"jest-jasmine2": {
-			"version": "26.4.2",
-			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.4.2.tgz",
-			"integrity": "sha512-z7H4EpCldHN1J8fNgsja58QftxBSL+JcwZmaXIvV9WKIM+x49F4GLHu/+BQh2kzRKHAgaN/E82od+8rTOBPyPA==",
+			"version": "26.5.3",
+			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.5.3.tgz",
+			"integrity": "sha512-nFlZOpnGlNc7y/+UkkeHnvbOM+rLz4wB1AimgI9QhtnqSZte0wYjbAm8hf7TCwXlXgDwZxAXo6z0a2Wzn9FoOg==",
 			"dev": true,
 			"requires": {
 				"@babel/traverse": "^7.1.0",
-				"@jest/environment": "^26.3.0",
-				"@jest/source-map": "^26.3.0",
-				"@jest/test-result": "^26.3.0",
-				"@jest/types": "^26.3.0",
+				"@jest/environment": "^26.5.2",
+				"@jest/source-map": "^26.5.0",
+				"@jest/test-result": "^26.5.2",
+				"@jest/types": "^26.5.2",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
 				"co": "^4.6.0",
-				"expect": "^26.4.2",
+				"expect": "^26.5.3",
 				"is-generator-fn": "^2.0.0",
-				"jest-each": "^26.4.2",
-				"jest-matcher-utils": "^26.4.2",
-				"jest-message-util": "^26.3.0",
-				"jest-runtime": "^26.4.2",
-				"jest-snapshot": "^26.4.2",
-				"jest-util": "^26.3.0",
-				"pretty-format": "^26.4.2",
+				"jest-each": "^26.5.2",
+				"jest-matcher-utils": "^26.5.2",
+				"jest-message-util": "^26.5.2",
+				"jest-runtime": "^26.5.3",
+				"jest-snapshot": "^26.5.3",
+				"jest-util": "^26.5.2",
+				"pretty-format": "^26.5.2",
 				"throat": "^5.0.0"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"version": "26.5.2",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -5436,21 +5433,20 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
-					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
+					"version": "15.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
+					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
 				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -5480,9 +5476,9 @@
 					"dev": true
 				},
 				"diff-sequences": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.3.0.tgz",
-					"integrity": "sha512-5j5vdRcw3CNctePNYN0Wy2e/JbWT6cAYnXv5OuqPhDpyCGc0uLu2TK0zOCJWNB9kOIfYMSpIulRaDgIi4HJ6Ig==",
+					"version": "26.5.0",
+					"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.5.0.tgz",
+					"integrity": "sha512-ZXx86srb/iYy6jG71k++wBN9P9J05UNQ5hQHQd9MtMPvcqXPx/vKU69jfHV637D00Q2gSgPk2D+jSx3l1lDW/Q==",
 					"dev": true
 				},
 				"has-flag": {
@@ -5492,15 +5488,15 @@
 					"dev": true
 				},
 				"jest-diff": {
-					"version": "26.4.2",
-					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.4.2.tgz",
-					"integrity": "sha512-6T1XQY8U28WH0Z5rGpQ+VqZSZz8EN8rZcBtfvXaOkbwxIEeRre6qnuZQlbY1AJ4MKDxQF8EkrCvK+hL/VkyYLQ==",
+					"version": "26.5.2",
+					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.5.2.tgz",
+					"integrity": "sha512-HCSWDUGwsov5oTlGzrRM+UPJI/Dpqi9jzeV0fdRNi3Ch5bnoXhnyJMmVg2juv9081zLIy3HGPI5mcuGgXM2xRA==",
 					"dev": true,
 					"requires": {
 						"chalk": "^4.0.0",
-						"diff-sequences": "^26.3.0",
+						"diff-sequences": "^26.5.0",
 						"jest-get-type": "^26.3.0",
-						"pretty-format": "^26.4.2"
+						"pretty-format": "^26.5.2"
 					}
 				},
 				"jest-get-type": {
@@ -5510,24 +5506,24 @@
 					"dev": true
 				},
 				"jest-matcher-utils": {
-					"version": "26.4.2",
-					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.4.2.tgz",
-					"integrity": "sha512-KcbNqWfWUG24R7tu9WcAOKKdiXiXCbMvQYT6iodZ9k1f7065k0keUOW6XpJMMvah+hTfqkhJhRXmA3r3zMAg0Q==",
+					"version": "26.5.2",
+					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.5.2.tgz",
+					"integrity": "sha512-W9GO9KBIC4gIArsNqDUKsLnhivaqf8MSs6ujO/JDcPIQrmY+aasewweXVET8KdrJ6ADQaUne5UzysvF/RR7JYA==",
 					"dev": true,
 					"requires": {
 						"chalk": "^4.0.0",
-						"jest-diff": "^26.4.2",
+						"jest-diff": "^26.5.2",
 						"jest-get-type": "^26.3.0",
-						"pretty-format": "^26.4.2"
+						"pretty-format": "^26.5.2"
 					}
 				},
 				"pretty-format": {
-					"version": "26.4.2",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
-					"integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
+					"version": "26.5.2",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.2.tgz",
+					"integrity": "sha512-VizyV669eqESlkOikKJI8Ryxl/kPpbdLwNdPs2GrbQs18MpySB5S0Yo0N7zkg2xTRiFq4CFw8ct5Vg4a0xP0og==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^26.3.0",
+						"@jest/types": "^26.5.2",
 						"ansi-regex": "^5.0.0",
 						"ansi-styles": "^4.0.0",
 						"react-is": "^16.12.0"
@@ -5562,19 +5558,19 @@
 			}
 		},
 		"jest-leak-detector": {
-			"version": "26.4.2",
-			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.4.2.tgz",
-			"integrity": "sha512-akzGcxwxtE+9ZJZRW+M2o+nTNnmQZxrHJxX/HjgDaU5+PLmY1qnQPnMjgADPGCRPhB+Yawe1iij0REe+k/aHoA==",
+			"version": "26.5.2",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.5.2.tgz",
+			"integrity": "sha512-h7ia3dLzBFItmYERaLPEtEKxy3YlcbcRSjj0XRNJgBEyODuu+3DM2o62kvIFvs3PsaYoIIv+e+nLRI61Dj1CNw==",
 			"dev": true,
 			"requires": {
 				"jest-get-type": "^26.3.0",
-				"pretty-format": "^26.4.2"
+				"pretty-format": "^26.5.2"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"version": "26.5.2",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -5594,21 +5590,20 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
-					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
+					"version": "15.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
+					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
 				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -5650,12 +5645,12 @@
 					"dev": true
 				},
 				"pretty-format": {
-					"version": "26.4.2",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
-					"integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
+					"version": "26.5.2",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.2.tgz",
+					"integrity": "sha512-VizyV669eqESlkOikKJI8Ryxl/kPpbdLwNdPs2GrbQs18MpySB5S0Yo0N7zkg2xTRiFq4CFw8ct5Vg4a0xP0og==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^26.3.0",
+						"@jest/types": "^26.5.2",
 						"ansi-regex": "^5.0.0",
 						"ansi-styles": "^4.0.0",
 						"react-is": "^16.12.0"
@@ -5691,14 +5686,14 @@
 			}
 		},
 		"jest-message-util": {
-			"version": "26.3.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.3.0.tgz",
-			"integrity": "sha512-xIavRYqr4/otGOiLxLZGj3ieMmjcNE73Ui+LdSW/Y790j5acqCsAdDiLIbzHCZMpN07JOENRWX5DcU+OQ+TjTA==",
+			"version": "26.5.2",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.5.2.tgz",
+			"integrity": "sha512-Ocp9UYZ5Jl15C5PNsoDiGEk14A4NG0zZKknpWdZGoMzJuGAkVt10e97tnEVMYpk7LnQHZOfuK2j/izLBMcuCZw==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@jest/types": "^26.3.0",
-				"@types/stack-utils": "^1.0.1",
+				"@jest/types": "^26.5.2",
+				"@types/stack-utils": "^2.0.0",
 				"chalk": "^4.0.0",
 				"graceful-fs": "^4.2.4",
 				"micromatch": "^4.0.2",
@@ -5707,9 +5702,9 @@
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"version": "26.5.2",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -5729,21 +5724,20 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
-					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
+					"version": "15.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
+					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
 				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -5790,19 +5784,19 @@
 			}
 		},
 		"jest-mock": {
-			"version": "26.3.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.3.0.tgz",
-			"integrity": "sha512-PeaRrg8Dc6mnS35gOo/CbZovoDPKAeB1FICZiuagAgGvbWdNNyjQjkOaGUa/3N3JtpQ/Mh9P4A2D4Fv51NnP8Q==",
+			"version": "26.5.2",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.5.2.tgz",
+			"integrity": "sha512-9SiU4b5PtO51v0MtJwVRqeGEroH66Bnwtq4ARdNP7jNXbpT7+ByeWNAk4NeT/uHfNSVDXEXgQo1XRuwEqS6Rdw==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^26.3.0",
+				"@jest/types": "^26.5.2",
 				"@types/node": "*"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"version": "26.5.2",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -5822,21 +5816,20 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
-					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
+					"version": "15.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
+					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
 				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -5895,25 +5888,25 @@
 			"dev": true
 		},
 		"jest-resolve": {
-			"version": "26.4.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.4.0.tgz",
-			"integrity": "sha512-bn/JoZTEXRSlEx3+SfgZcJAVuTMOksYq9xe9O6s4Ekg84aKBObEaVXKOEilULRqviSLAYJldnoWV9c07kwtiCg==",
+			"version": "26.5.2",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.5.2.tgz",
+			"integrity": "sha512-XsPxojXGRA0CoDD7Vis59ucz2p3cQFU5C+19tz3tLEAlhYKkK77IL0cjYjikY9wXnOaBeEdm1rOgSJjbZWpcZg==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^26.3.0",
+				"@jest/types": "^26.5.2",
 				"chalk": "^4.0.0",
 				"graceful-fs": "^4.2.4",
 				"jest-pnp-resolver": "^1.2.2",
-				"jest-util": "^26.3.0",
+				"jest-util": "^26.5.2",
 				"read-pkg-up": "^7.0.1",
 				"resolve": "^1.17.0",
 				"slash": "^3.0.0"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"version": "26.5.2",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -5933,21 +5926,20 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
-					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
+					"version": "15.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
+					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
 				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -6086,20 +6078,20 @@
 			}
 		},
 		"jest-resolve-dependencies": {
-			"version": "26.4.2",
-			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.4.2.tgz",
-			"integrity": "sha512-ADHaOwqEcVc71uTfySzSowA/RdxUpCxhxa2FNLiin9vWLB1uLPad3we+JSSROq5+SrL9iYPdZZF8bdKM7XABTQ==",
+			"version": "26.5.3",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.5.3.tgz",
+			"integrity": "sha512-+KMDeke/BFK+mIQ2IYSyBz010h7zQaVt4Xie6cLqUGChorx66vVeQVv4ErNoMwInnyYHi1Ud73tDS01UbXbfLQ==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^26.3.0",
+				"@jest/types": "^26.5.2",
 				"jest-regex-util": "^26.0.0",
-				"jest-snapshot": "^26.4.2"
+				"jest-snapshot": "^26.5.3"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"version": "26.5.2",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -6119,21 +6111,20 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
-					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
+					"version": "15.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
+					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
 				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -6180,37 +6171,37 @@
 			}
 		},
 		"jest-runner": {
-			"version": "26.4.2",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.4.2.tgz",
-			"integrity": "sha512-FgjDHeVknDjw1gRAYaoUoShe1K3XUuFMkIaXbdhEys+1O4bEJS8Avmn4lBwoMfL8O5oFTdWYKcf3tEJyyYyk8g==",
+			"version": "26.5.3",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.5.3.tgz",
+			"integrity": "sha512-qproP0Pq7IIule+263W57k2+8kWCszVJTC9TJWGUz0xJBr+gNiniGXlG8rotd0XxwonD5UiJloYoSO5vbUr5FQ==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^26.3.0",
-				"@jest/environment": "^26.3.0",
-				"@jest/test-result": "^26.3.0",
-				"@jest/types": "^26.3.0",
+				"@jest/console": "^26.5.2",
+				"@jest/environment": "^26.5.2",
+				"@jest/test-result": "^26.5.2",
+				"@jest/types": "^26.5.2",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
 				"emittery": "^0.7.1",
 				"exit": "^0.1.2",
 				"graceful-fs": "^4.2.4",
-				"jest-config": "^26.4.2",
+				"jest-config": "^26.5.3",
 				"jest-docblock": "^26.0.0",
-				"jest-haste-map": "^26.3.0",
-				"jest-leak-detector": "^26.4.2",
-				"jest-message-util": "^26.3.0",
-				"jest-resolve": "^26.4.0",
-				"jest-runtime": "^26.4.2",
-				"jest-util": "^26.3.0",
-				"jest-worker": "^26.3.0",
+				"jest-haste-map": "^26.5.2",
+				"jest-leak-detector": "^26.5.2",
+				"jest-message-util": "^26.5.2",
+				"jest-resolve": "^26.5.2",
+				"jest-runtime": "^26.5.3",
+				"jest-util": "^26.5.2",
+				"jest-worker": "^26.5.0",
 				"source-map-support": "^0.5.6",
 				"throat": "^5.0.0"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"version": "26.5.2",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -6230,21 +6221,20 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
-					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
+					"version": "15.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
+					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
 				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -6291,43 +6281,43 @@
 			}
 		},
 		"jest-runtime": {
-			"version": "26.4.2",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.4.2.tgz",
-			"integrity": "sha512-4Pe7Uk5a80FnbHwSOk7ojNCJvz3Ks2CNQWT5Z7MJo4tX0jb3V/LThKvD9tKPNVNyeMH98J/nzGlcwc00R2dSHQ==",
+			"version": "26.5.3",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.5.3.tgz",
+			"integrity": "sha512-IDjalmn2s/Tc4GvUwhPHZ0iaXCdMRq5p6taW9P8RpU+FpG01O3+H8z+p3rDCQ9mbyyyviDgxy/LHPLzrIOKBkQ==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^26.3.0",
-				"@jest/environment": "^26.3.0",
-				"@jest/fake-timers": "^26.3.0",
-				"@jest/globals": "^26.4.2",
-				"@jest/source-map": "^26.3.0",
-				"@jest/test-result": "^26.3.0",
-				"@jest/transform": "^26.3.0",
-				"@jest/types": "^26.3.0",
+				"@jest/console": "^26.5.2",
+				"@jest/environment": "^26.5.2",
+				"@jest/fake-timers": "^26.5.2",
+				"@jest/globals": "^26.5.3",
+				"@jest/source-map": "^26.5.0",
+				"@jest/test-result": "^26.5.2",
+				"@jest/transform": "^26.5.2",
+				"@jest/types": "^26.5.2",
 				"@types/yargs": "^15.0.0",
 				"chalk": "^4.0.0",
 				"collect-v8-coverage": "^1.0.0",
 				"exit": "^0.1.2",
 				"glob": "^7.1.3",
 				"graceful-fs": "^4.2.4",
-				"jest-config": "^26.4.2",
-				"jest-haste-map": "^26.3.0",
-				"jest-message-util": "^26.3.0",
-				"jest-mock": "^26.3.0",
+				"jest-config": "^26.5.3",
+				"jest-haste-map": "^26.5.2",
+				"jest-message-util": "^26.5.2",
+				"jest-mock": "^26.5.2",
 				"jest-regex-util": "^26.0.0",
-				"jest-resolve": "^26.4.0",
-				"jest-snapshot": "^26.4.2",
-				"jest-util": "^26.3.0",
-				"jest-validate": "^26.4.2",
+				"jest-resolve": "^26.5.2",
+				"jest-snapshot": "^26.5.3",
+				"jest-util": "^26.5.2",
+				"jest-validate": "^26.5.3",
 				"slash": "^3.0.0",
 				"strip-bom": "^4.0.0",
-				"yargs": "^15.3.1"
+				"yargs": "^15.4.1"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"version": "26.5.2",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -6347,21 +6337,20 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
-					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
+					"version": "15.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
+					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
 				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -6414,9 +6403,9 @@
 			}
 		},
 		"jest-serializer": {
-			"version": "26.3.0",
-			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.3.0.tgz",
-			"integrity": "sha512-IDRBQBLPlKa4flg77fqg0n/pH87tcRKwe8zxOVTWISxGpPHYkRZ1dXKyh04JOja7gppc60+soKVZ791mruVdow==",
+			"version": "26.5.0",
+			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.5.0.tgz",
+			"integrity": "sha512-+h3Gf5CDRlSLdgTv7y0vPIAoLgX/SI7T4v6hy+TEXMgYbv+ztzbg5PSN6mUXAT/hXYHvZRWm+MaObVfqkhCGxA==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*",
@@ -6424,32 +6413,33 @@
 			}
 		},
 		"jest-snapshot": {
-			"version": "26.4.2",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.4.2.tgz",
-			"integrity": "sha512-N6Uub8FccKlf5SBFnL2Ri/xofbaA68Cc3MGjP/NuwgnsvWh+9hLIR/DhrxbSiKXMY9vUW5dI6EW1eHaDHqe9sg==",
+			"version": "26.5.3",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.5.3.tgz",
+			"integrity": "sha512-ZgAk0Wm0JJ75WS4lGaeRfa0zIgpL0KD595+XmtwlIEMe8j4FaYHyZhP1LNOO+8fXq7HJ3hll54+sFV9X4+CGVw==",
 			"dev": true,
 			"requires": {
 				"@babel/types": "^7.0.0",
-				"@jest/types": "^26.3.0",
+				"@jest/types": "^26.5.2",
+				"@types/babel__traverse": "^7.0.4",
 				"@types/prettier": "^2.0.0",
 				"chalk": "^4.0.0",
-				"expect": "^26.4.2",
+				"expect": "^26.5.3",
 				"graceful-fs": "^4.2.4",
-				"jest-diff": "^26.4.2",
+				"jest-diff": "^26.5.2",
 				"jest-get-type": "^26.3.0",
-				"jest-haste-map": "^26.3.0",
-				"jest-matcher-utils": "^26.4.2",
-				"jest-message-util": "^26.3.0",
-				"jest-resolve": "^26.4.0",
+				"jest-haste-map": "^26.5.2",
+				"jest-matcher-utils": "^26.5.2",
+				"jest-message-util": "^26.5.2",
+				"jest-resolve": "^26.5.2",
 				"natural-compare": "^1.4.0",
-				"pretty-format": "^26.4.2",
+				"pretty-format": "^26.5.2",
 				"semver": "^7.3.2"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"version": "26.5.2",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -6469,21 +6459,20 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
-					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
+					"version": "15.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
+					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
 				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -6513,9 +6502,9 @@
 					"dev": true
 				},
 				"diff-sequences": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.3.0.tgz",
-					"integrity": "sha512-5j5vdRcw3CNctePNYN0Wy2e/JbWT6cAYnXv5OuqPhDpyCGc0uLu2TK0zOCJWNB9kOIfYMSpIulRaDgIi4HJ6Ig==",
+					"version": "26.5.0",
+					"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.5.0.tgz",
+					"integrity": "sha512-ZXx86srb/iYy6jG71k++wBN9P9J05UNQ5hQHQd9MtMPvcqXPx/vKU69jfHV637D00Q2gSgPk2D+jSx3l1lDW/Q==",
 					"dev": true
 				},
 				"has-flag": {
@@ -6525,15 +6514,15 @@
 					"dev": true
 				},
 				"jest-diff": {
-					"version": "26.4.2",
-					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.4.2.tgz",
-					"integrity": "sha512-6T1XQY8U28WH0Z5rGpQ+VqZSZz8EN8rZcBtfvXaOkbwxIEeRre6qnuZQlbY1AJ4MKDxQF8EkrCvK+hL/VkyYLQ==",
+					"version": "26.5.2",
+					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.5.2.tgz",
+					"integrity": "sha512-HCSWDUGwsov5oTlGzrRM+UPJI/Dpqi9jzeV0fdRNi3Ch5bnoXhnyJMmVg2juv9081zLIy3HGPI5mcuGgXM2xRA==",
 					"dev": true,
 					"requires": {
 						"chalk": "^4.0.0",
-						"diff-sequences": "^26.3.0",
+						"diff-sequences": "^26.5.0",
 						"jest-get-type": "^26.3.0",
-						"pretty-format": "^26.4.2"
+						"pretty-format": "^26.5.2"
 					}
 				},
 				"jest-get-type": {
@@ -6543,24 +6532,24 @@
 					"dev": true
 				},
 				"jest-matcher-utils": {
-					"version": "26.4.2",
-					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.4.2.tgz",
-					"integrity": "sha512-KcbNqWfWUG24R7tu9WcAOKKdiXiXCbMvQYT6iodZ9k1f7065k0keUOW6XpJMMvah+hTfqkhJhRXmA3r3zMAg0Q==",
+					"version": "26.5.2",
+					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.5.2.tgz",
+					"integrity": "sha512-W9GO9KBIC4gIArsNqDUKsLnhivaqf8MSs6ujO/JDcPIQrmY+aasewweXVET8KdrJ6ADQaUne5UzysvF/RR7JYA==",
 					"dev": true,
 					"requires": {
 						"chalk": "^4.0.0",
-						"jest-diff": "^26.4.2",
+						"jest-diff": "^26.5.2",
 						"jest-get-type": "^26.3.0",
-						"pretty-format": "^26.4.2"
+						"pretty-format": "^26.5.2"
 					}
 				},
 				"pretty-format": {
-					"version": "26.4.2",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
-					"integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
+					"version": "26.5.2",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.2.tgz",
+					"integrity": "sha512-VizyV669eqESlkOikKJI8Ryxl/kPpbdLwNdPs2GrbQs18MpySB5S0Yo0N7zkg2xTRiFq4CFw8ct5Vg4a0xP0og==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^26.3.0",
+						"@jest/types": "^26.5.2",
 						"ansi-regex": "^5.0.0",
 						"ansi-styles": "^4.0.0",
 						"react-is": "^16.12.0"
@@ -6584,12 +6573,12 @@
 			}
 		},
 		"jest-util": {
-			"version": "26.3.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.3.0.tgz",
-			"integrity": "sha512-4zpn6bwV0+AMFN0IYhH/wnzIQzRaYVrz1A8sYnRnj4UXDXbOVtWmlaZkO9mipFqZ13okIfN87aDoJWB7VH6hcw==",
+			"version": "26.5.2",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.2.tgz",
+			"integrity": "sha512-WTL675bK+GSSAYgS8z9FWdCT2nccO1yTIplNLPlP0OD8tUk/H5IrWKMMRudIQQ0qp8bb4k+1Qa8CxGKq9qnYdg==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^26.3.0",
+				"@jest/types": "^26.5.2",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
 				"graceful-fs": "^4.2.4",
@@ -6598,9 +6587,9 @@
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"version": "26.5.2",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -6620,21 +6609,20 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
-					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
+					"version": "15.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
+					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
 				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -6681,23 +6669,23 @@
 			}
 		},
 		"jest-validate": {
-			"version": "26.4.2",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.4.2.tgz",
-			"integrity": "sha512-blft+xDX7XXghfhY0mrsBCYhX365n8K5wNDC4XAcNKqqjEzsRUSXP44m6PL0QJEW2crxQFLLztVnJ4j7oPlQrQ==",
+			"version": "26.5.3",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.5.3.tgz",
+			"integrity": "sha512-LX07qKeAtY+lsU0o3IvfDdN5KH9OulEGOMN1sFo6PnEf5/qjS1LZIwNk9blcBeW94pQUI9dLN9FlDYDWI5tyaA==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^26.3.0",
+				"@jest/types": "^26.5.2",
 				"camelcase": "^6.0.0",
 				"chalk": "^4.0.0",
 				"jest-get-type": "^26.3.0",
 				"leven": "^3.1.0",
-				"pretty-format": "^26.4.2"
+				"pretty-format": "^26.5.2"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"version": "26.5.2",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -6717,28 +6705,27 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
-					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
+					"version": "15.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
+					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
 				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
 				"camelcase": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
-					"integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==",
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.1.0.tgz",
+					"integrity": "sha512-WCMml9ivU60+8rEJgELlFp1gxFcEGxwYleE3bziHEDeqsqAWGHdimB7beBFGjLzVNgPGyDsfgXLQEYMpmIFnVQ==",
 					"dev": true
 				},
 				"chalk": {
@@ -6779,12 +6766,12 @@
 					"dev": true
 				},
 				"pretty-format": {
-					"version": "26.4.2",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
-					"integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
+					"version": "26.5.2",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.2.tgz",
+					"integrity": "sha512-VizyV669eqESlkOikKJI8Ryxl/kPpbdLwNdPs2GrbQs18MpySB5S0Yo0N7zkg2xTRiFq4CFw8ct5Vg4a0xP0og==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^26.3.0",
+						"@jest/types": "^26.5.2",
 						"ansi-regex": "^5.0.0",
 						"ansi-styles": "^4.0.0",
 						"react-is": "^16.12.0"
@@ -6808,24 +6795,24 @@
 			}
 		},
 		"jest-watcher": {
-			"version": "26.3.0",
-			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.3.0.tgz",
-			"integrity": "sha512-XnLdKmyCGJ3VoF6G/p5ohbJ04q/vv5aH9ENI+i6BL0uu9WWB6Z7Z2lhQQk0d2AVZcRGp1yW+/TsoToMhBFPRdQ==",
+			"version": "26.5.2",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.5.2.tgz",
+			"integrity": "sha512-i3m1NtWzF+FXfJ3ljLBB/WQEp4uaNhX7QcQUWMokcifFTUQBDFyUMEwk0JkJ1kopHbx7Een3KX0Q7+9koGM/Pw==",
 			"dev": true,
 			"requires": {
-				"@jest/test-result": "^26.3.0",
-				"@jest/types": "^26.3.0",
+				"@jest/test-result": "^26.5.2",
+				"@jest/types": "^26.5.2",
 				"@types/node": "*",
 				"ansi-escapes": "^4.2.1",
 				"chalk": "^4.0.0",
-				"jest-util": "^26.3.0",
+				"jest-util": "^26.5.2",
 				"string-length": "^4.0.1"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"version": "26.5.2",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -6845,21 +6832,20 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
-					"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
+					"version": "15.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
+					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
 				},
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -6906,9 +6892,9 @@
 			}
 		},
 		"jest-worker": {
-			"version": "26.3.0",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.3.0.tgz",
-			"integrity": "sha512-Vmpn2F6IASefL+DVBhPzI2J9/GJUsqzomdeN+P+dK8/jKxbh8R3BtFnx3FIta7wYlPU62cpJMJQo4kuOowcMnw==",
+			"version": "26.5.0",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.5.0.tgz",
+			"integrity": "sha512-kTw66Dn4ZX7WpjZ7T/SUDgRhapFRKWmisVAF0Rv4Fu8SLFD7eLbqpLvbxVqYhSgaWa7I+bW7pHnbyfNsH6stug==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*",
@@ -9230,9 +9216,9 @@
 			}
 		},
 		"tslib": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-			"integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
 			"dev": true
 		},
 		"tsutils": {
@@ -9388,9 +9374,9 @@
 			"dev": true
 		},
 		"uuid": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
-			"integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==",
+			"version": "8.3.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
+			"integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==",
 			"dev": true,
 			"optional": true
 		},
@@ -9401,9 +9387,9 @@
 			"dev": true
 		},
 		"v8-to-istanbul": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-5.0.1.tgz",
-			"integrity": "sha512-mbDNjuDajqYe3TXFk5qxcQy8L1msXNE37WTlLoqqpBfRsimbNcrlhQlDPntmECEcUvdC+AQ8CyMMf6EUx1r74Q==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-6.0.1.tgz",
+			"integrity": "sha512-PzM1WlqquhBvsV+Gco6WSFeg1AGdD53ccMRkFeyHRE/KRZaVacPOmQYP3EeVgDBtKD2BJ8kgynBQ5OtKiHCH+w==",
 			"dev": true,
 			"requires": {
 				"@types/istanbul-lib-coverage": "^2.0.1",
@@ -9495,9 +9481,9 @@
 			"dev": true
 		},
 		"whatwg-url": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.3.0.tgz",
-			"integrity": "sha512-BQRf/ej5Rp3+n7k0grQXZj9a1cHtsp4lqj01p59xBWFKdezR8sO37XnpafwNqiFac/v2Il12EIMjX/Y4VZtT8Q==",
+			"version": "8.4.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.4.0.tgz",
+			"integrity": "sha512-vwTUFf6V4zhcPkWp/4CQPr1TW9Ml6SF4lVyaIMBdJw5i6qUUJ1QWM4Z6YYVkfka0OUIzVo/0aNtGVGk256IKWw==",
 			"dev": true,
 			"requires": {
 				"lodash.sortby": "^4.7.0",
@@ -9554,12 +9540,11 @@
 			},
 			"dependencies": {
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},

--- a/package-lock.json
+++ b/package-lock.json
@@ -2625,11 +2625,19 @@
 			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
 			"dev": true
 		},
+		"deepdash": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/deepdash/-/deepdash-5.3.0.tgz",
+			"integrity": "sha512-4/nV/Q/pGg6LM5xVDHeuGNVp9ljSifywGme1p6kB4RY64V+UiZ0RLXOsKzMlOIcrQKPeXQKVuimdN5aHyHOEUA==",
+			"requires": {
+				"lodash": "^4.17.19",
+				"lodash-es": "^4.17.15"
+			}
+		},
 		"deepmerge": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-			"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-			"dev": true
+			"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
 		},
 		"define-properties": {
 			"version": "1.1.3",
@@ -7238,6 +7246,11 @@
 			"version": "4.17.20",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
 			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+		},
+		"lodash-es": {
+			"version": "4.17.15",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.15.tgz",
+			"integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ=="
 		},
 		"lodash.camelcase": {
 			"version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
 		"coverage": "npm run test -- --coverage",
 		"lint": "./node_modules/.bin/eslint . --fix",
 		"test": "jest tests",
-		"test:watch": "jest tests --watch --notify"
+		"test:watch": "jest tests --watch --notify",
+		"update": "npx npm-check-updates -u && npm install"
 	},
 	"repository": {
 		"type": "git",
@@ -28,21 +29,21 @@
 	},
 	"homepage": "https://github.com/trayio/connector-utils#readme",
 	"devDependencies": {
-		"eslint": "^6.8.0",
-		"eslint-config-airbnb-base": "^14.1.0",
-		"eslint-config-prettier": "^6.10.0",
-		"eslint-plugin-import": "^2.20.1",
-		"eslint-plugin-jest": "^23.8.2",
-		"eslint-plugin-jsx-a11y": "^6.2.3",
-		"eslint-plugin-prettier": "^3.1.2",
+		"eslint": "^7.10.0",
+		"eslint-config-airbnb-base": "^14.2.0",
+		"eslint-config-prettier": "^6.12.0",
+		"eslint-plugin-import": "^2.22.1",
+		"eslint-plugin-jest": "^24.0.2",
+		"eslint-plugin-jsx-a11y": "^6.3.1",
+		"eslint-plugin-prettier": "^3.1.4",
 		"eslint-plugin-promise": "^4.2.1",
-		"jest": "^25.1.0",
+		"jest": "^26.4.2",
 		"jest-json-schema": "^2.1.0",
-		"jsdoc-to-markdown": "^5.0.3",
-		"prettier": "^1.19.1"
+		"jsdoc-to-markdown": "^6.0.1",
+		"prettier": "^2.1.2"
 	},
 	"dependencies": {
-		"lodash": "~4.17.15",
+		"lodash": "~4.17.20",
 		"mustache": "^4.0.1"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
 		"prettier": "^2.1.2"
 	},
 	"dependencies": {
+		"deepdash": "^5.3.0",
+		"deepmerge": "^4.2.2",
 		"lodash": "~4.17.20",
 		"mustache": "^4.0.1"
 	}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@trayio/connector-utils",
-	"version": "0.3.3",
+	"version": "0.3.4",
 	"description": "Common utility functions used in connectors.",
 	"main": "lib/index.js",
 	"scripts": {
@@ -29,15 +29,15 @@
 	},
 	"homepage": "https://github.com/trayio/connector-utils#readme",
 	"devDependencies": {
-		"eslint": "^7.10.0",
+		"eslint": "^7.11.0",
 		"eslint-config-airbnb-base": "^14.2.0",
 		"eslint-config-prettier": "^6.12.0",
 		"eslint-plugin-import": "^2.22.1",
-		"eslint-plugin-jest": "^24.0.2",
+		"eslint-plugin-jest": "^24.1.0",
 		"eslint-plugin-jsx-a11y": "^6.3.1",
 		"eslint-plugin-prettier": "^3.1.4",
 		"eslint-plugin-promise": "^4.2.1",
-		"jest": "^26.4.2",
+		"jest": "^26.5.3",
 		"jest-json-schema": "^2.1.0",
 		"jsdoc-to-markdown": "^6.0.1",
 		"prettier": "^2.1.2"

--- a/schema-generation.md
+++ b/schema-generation.md
@@ -14,9 +14,9 @@ The `schema.js` files only require one function for schema generation. The way t
 
 The operation input schema returned from the generator function is a deep copy of the original schema definition. Therefore, you cannot mutate or alter the original schema in any way.
 
-### Easy override of properties
+### Easy override of properties with deep merge
 
-The original schema definition defines the standard properties to be used by the connector operations but it is easy to override any schema property in any operation by providing a new value.
+The original schema definition defines the standard properties to be used by the connector operations but it is easy to override any schema property in any operation by providing a new value. Overrides are applied using a deep merge algorithm.
 
 ### DRY schema elements
 
@@ -58,10 +58,11 @@ module.exports = {
 				description: 'Number of units ordered.',
 			},
 			notes: { description: 'Notes for this specific ordered product.' },
-			is_packed: {},
+			is_packed: { alias: 'packed' },
 			packed_at: {},
 			packed_by: {},
 		},
+		arrayMergeType: 'concatenate',
 	}),
 };
 ```
@@ -95,19 +96,15 @@ module.exports = {
             notes: { description: 'Notes for this specific ordered product.' },
         ```
 
-    4. The rest of the keys will take values that have been defined in the standard schema definition. This is done by assigning an empty object `{}` to the keys. Since the object contains no keys or values, there is nothing to override.
+    4. The fourth key (`is_packed`) defines an alias to override the original key. When the schema is generated, all references to `is_packed` will be replaced by `packed`. You will therefore reference this schema key as `packed` in the operation's parameters and model.
 
-## Sample Connector
+    5. The rest of the keys will take values that have been defined in the standard schema definition. This is done by assigning an empty object `{}` to the keys. Since the object contains no keys or values, there is nothing to override.
 
-The `connector-utils` package contains a sample connector wit unit tests. You can view the code here and see how it all fits together. It includes:
-
--   Helper files to define and assemble the connector's full input schema
--   Operations that use the generator function
--   Unit tests that verify that the schema was generated correctly and that problems were logged correctly.
+    6. Finally, you may (optionally) specify the merge strategy for arrays. In this example, we are saying that we wish arrays to be concatenated when merging (which is the default strategy).
 
 ## Logging Schema Issues
 
-The schema generator automatically checks the generated schema for issues. It will detect when `type` keys and `description` keys are missing.
+The schema generator automatically checks the generated schema for issues. It will detect when `type` keys and `description` keys are missing. It will also report missing full stops in descriptions.
 
 Issues are logged to the console whenever the schema is generated. In practice, this means that whenever you invoke the `test-runner` or `node-dev main.js` you will be able to see and fix schema issues.
 
@@ -125,10 +122,77 @@ When using `node-dev main.js`:
 
 ![Node-dev log](./img/node-dev-log.png)
 
-Missing `description`s are logged as warnings.
+Missing `description`s and full stops are logged as warnings.
 
 This is really useful for catching and fixing QA issues (before they happen) where input tooltips are missing.
 
 Missing `type`s are logged as errors.
 
 If you see missing types it usually means that the schema key that you requested doesn't exist in the full connector schema object.
+
+## Deep Merge of Objects and Arrays
+
+When overriding schema elements with new schema fragments, we deep merge the existing and new schemas together. All mergeable objects will be deep merged. However, some schema element types need to be merged in specific ways. Arrays can be merged in a number of different ways:
+
+### Concatenating Arrays
+
+Setting `arrayMergeType`: `'concatenate'` will merge arrays by concatenating values (default).
+
+e.g.
+
+-   original: `['One', 'Two', 'Three']`
+-   override: `['Four', 'Five']`
+-   result: `['One', 'Two', 'Three', 'Four', 'Five']`
+
+### Combine Arrays by Index
+
+Setting `arrayMergeType`: `'combineByIndex'` will merge/combine arrays by index value.
+
+-   arrays of objects will merge by index (if possible)
+-   other types will concatenate (ignoring value duplication overlap)
+
+e.g.
+
+-   original: `['One', 'Two', 'Three']`
+-   override: `['Two', 'Four', 'One', 'Five']`
+-   result: `['One', 'Two', 'Three', 'Four', 'Five']`
+
+**Explanation:**
+
+We start by copying the original array and this forms the basis of the output array. Looking at the override array:
+
+-   Index 0 - `Two` already exists in the original array so it is ignored.
+-   Index 1 - `Four` is appended because it does not appear at index 0, 1 or 2 of the original array.
+-   Index 2 - `One` already exists in the original array so it is ignored.
+-   Index 3 - `Five` is appended because its index is beyond the scope of the original array.
+
+### Overwrite Arrays by Index
+
+Setting `arrayMergeType`: `'overwriteByIndex'` will merge/overwrite arrays by index value.
+
+-   arrays of objects will merge by index (if possible)
+-   other types will overwrite by index value
+
+e.g.
+
+-   original: `['One', 'Two', 'Three']`
+-   override: `['Three', 'Four']`
+-   result: `['Three', 'Four', 'Three']`
+
+**Explanation:**
+
+We start by copying the original array and this forms the basis of the output array. Looking at the override array:
+
+-   Index 0 - `Three` overwrites `One` at index 0 of the original array.
+-   Index 1 - `Four` overwrites `Two` at index 1 of the original array.
+-   Index 2 - The override array doesn't have a value at index 2 so the original value `Three` is kept.
+
+### Overwrite Arrays
+
+Setting `arrayMergeType`: `'overwrite'` will overwrite the original array with the specified array
+
+e.g.
+
+-   original: `['One', 'Two', 'Three']`
+-   override: `['Four', 'Five']`
+-   result: `['Four', 'Five']`

--- a/schema-generation.md
+++ b/schema-generation.md
@@ -134,15 +134,48 @@ If you see missing types it usually means that the schema key that you requested
 
 When overriding schema elements with new schema fragments, we deep merge the existing and new schemas together. All mergeable objects will be deep merged. However, some schema element types need to be merged in specific ways. Arrays can be merged in a number of different ways:
 
-### Concatenating Arrays
+### Concatenating Arrays (default)
 
 Setting `arrayMergeType`: `'concatenate'` will merge arrays by concatenating values (default).
 
-e.g.
+e.g. (`Strings`)
 
 -   original: `['One', 'Two', 'Three']`
 -   override: `['Four', 'Five']`
 -   result: `['One', 'Two', 'Three', 'Four', 'Five']`
+
+e.g. (`Objects`)
+
+-   original:
+
+```js
+[
+	{ text: 'One', value: 1 },
+	{ text: 'Two', value: 2 },
+	{ text: 'Three', value: 3 },
+];
+```
+
+-   override:
+
+```js
+[
+	{ text: 'Three', value: 3 },
+	{ text: 'Four', value: 4 },
+];
+```
+
+-   result:
+
+```js
+[
+	{ text: 'One', value: 1 },
+	{ text: 'Two', value: 2 },
+	{ text: 'Three', value: 3 },
+	{ text: 'Three', value: 3 },
+	{ text: 'Four', value: 4 },
+];
+```
 
 ### Combine Arrays by Index
 
@@ -151,7 +184,7 @@ Setting `arrayMergeType`: `'combineByIndex'` will merge/combine arrays by index 
 -   arrays of objects will merge by index (if possible)
 -   other types will concatenate (ignoring value duplication overlap)
 
-e.g.
+e.g. (`Strings`)
 
 -   original: `['One', 'Two', 'Three']`
 -   override: `['Two', 'Four', 'One', 'Five']`
@@ -166,6 +199,34 @@ We start by copying the original array and this forms the basis of the output ar
 -   Index 2 - `One` already exists in the original array so it is ignored.
 -   Index 3 - `Five` is appended because its index is beyond the scope of the original array.
 
+e.g. (`Objects`)
+
+-   original:
+
+```js
+[
+	{ text: 'One', value: 1 },
+	{ text: 'Two', value: 2 },
+	{ text: 'Three', value: 3 },
+];
+```
+
+-   override:
+
+```js
+[{ value: 4 }, { text: 'Five' }];
+```
+
+-   result:
+
+```js
+[
+	{ text: 'One', value: 4 },
+	{ text: 'Five', value: 2 },
+	{ text: 'Three', value: 3 },
+];
+```
+
 ### Overwrite Arrays by Index
 
 Setting `arrayMergeType`: `'overwriteByIndex'` will merge/overwrite arrays by index value.
@@ -173,7 +234,7 @@ Setting `arrayMergeType`: `'overwriteByIndex'` will merge/overwrite arrays by in
 -   arrays of objects will merge by index (if possible)
 -   other types will overwrite by index value
 
-e.g.
+e.g. (`Strings`)
 
 -   original: `['One', 'Two', 'Three']`
 -   override: `['Three', 'Four']`
@@ -187,12 +248,71 @@ We start by copying the original array and this forms the basis of the output ar
 -   Index 1 - `Four` overwrites `Two` at index 1 of the original array.
 -   Index 2 - The override array doesn't have a value at index 2 so the original value `Three` is kept.
 
+e.g. (`Objects`)
+
+-   original:
+
+```js
+[
+	{ text: 'One', value: 1 },
+	{ text: 'Two', value: 2 },
+	{ text: 'Three', value: 3 },
+];
+```
+
+-   override:
+
+```js
+[{}, { text: 'Five' }, { value: { key: 'value' } }, { text: 'Five', value: 1 }];
+```
+
+-   result:
+
+```js
+[
+	{ text: 'One', value: 1 },
+	{ text: 'Five', value: 2 },
+	{ text: 'Three', value: { key: 'value' } },
+	{ text: 'Five', value: 1 },
+];
+```
+
 ### Overwrite Arrays
 
 Setting `arrayMergeType`: `'overwrite'` will overwrite the original array with the specified array
 
-e.g.
+e.g. (`Strings`)
 
 -   original: `['One', 'Two', 'Three']`
 -   override: `['Four', 'Five']`
 -   result: `['Four', 'Five']`
+
+e.g. (`Objects`)
+
+-   original:
+
+```js
+[
+	{ text: 'One', value: 1 },
+	{ text: 'Two', value: 2 },
+	{ text: 'Three', value: 3 },
+];
+```
+
+-   override:
+
+```js
+[
+	{ text: 'One', value: 1 },
+	{ text: 'Five', value: 5 },
+];
+```
+
+-   result:
+
+```js
+[
+	{ text: 'One', value: 1 },
+	{ text: 'Five', value: 5 },
+];
+```

--- a/tests/methods/schema/alias.test.js
+++ b/tests/methods/schema/alias.test.js
@@ -1,0 +1,86 @@
+const { generateInputSchema } = require('../../../lib/index');
+const { fullSchema } = require('./schema');
+const { mockConsole, restoreConsole } = require('./console');
+
+describe('Generate input schemas', () => {
+	beforeEach(() => {
+		mockConsole();
+	});
+
+	afterEach(() => {
+		restoreConsole();
+	});
+
+	describe('Aliases', () => {
+		test('It should generate schema with top level aliases.', () => {
+			const generatedSchema = generateInputSchema({
+				schema: fullSchema,
+				keys: {
+					booleanType: { alias: 'booleanAlias' },
+					dateType: { alias: 'dateAlias' },
+					stringType: { alias: '' },
+				},
+				operation: 'testRequestTopLevelAliases',
+			});
+			expect(generatedSchema).toEqual({
+				booleanAlias: {
+					type: 'boolean',
+				},
+				dateAlias: {
+					date_mask: 'X',
+					format: 'datetime',
+				},
+				stringType: {
+					required: true,
+					type: 'string',
+				},
+			});
+		});
+
+		test('It should generate schema with deep aliases.', () => {
+			const generatedSchema = generateInputSchema({
+				schema: {},
+				keys: {
+					objectType: {
+						alias: 'aliasType',
+						type: 'object',
+						title: 'Parent',
+						properties: {
+							name: {
+								alias: '', // no alias defined so don't use it
+								type: 'string',
+							},
+							child: {
+								alias: 'aliasChild',
+								title: 'child',
+								properties: {
+									name: { type: 'string' },
+								},
+							},
+						},
+						additionalProperties: false,
+					},
+				},
+				operation: 'testRequestKeyAliases',
+			});
+			expect(generatedSchema).toEqual({
+				aliasType: {
+					type: 'object',
+					title: 'Parent',
+					properties: {
+						name: {
+							type: 'string',
+						},
+						aliasChild: {
+							title: 'child',
+							properties: {
+								name: { type: 'string' },
+							},
+						},
+					},
+					additionalProperties: false,
+				},
+			});
+		});
+	});
+});

--- a/tests/methods/schema/alias.test.js
+++ b/tests/methods/schema/alias.test.js
@@ -20,7 +20,7 @@ describe('Generate input schemas', () => {
 					dateType: { alias: 'dateAlias' },
 					stringType: { alias: '' },
 				},
-				operation: 'testRequestTopLevelAliases',
+				operation: 'topLevelAliases',
 			});
 			expect(generatedSchema).toEqual({
 				booleanAlias: {
@@ -61,7 +61,7 @@ describe('Generate input schemas', () => {
 						additionalProperties: false,
 					},
 				},
-				operation: 'testRequestKeyAliases',
+				operation: 'deepAliases',
 			});
 			expect(generatedSchema).toEqual({
 				aliasType: {

--- a/tests/methods/schema/arrayMerge.test.js
+++ b/tests/methods/schema/arrayMerge.test.js
@@ -21,7 +21,7 @@ describe('Generate input schemas', () => {
 				schema: fullSchema,
 				keys: {
 					enumStringType: {
-						enum: ['Four', 'Five'],
+						enum: ['Three', 'Four'],
 					},
 					enumValueType: {
 						enum: [
@@ -30,76 +30,18 @@ describe('Generate input schemas', () => {
 								value: 4,
 							},
 							{
-								text: 'Five',
-								value: 5,
-							},
-						],
-					},
-				},
-				operation: 'arrayConcatenateDefault',
-			});
-			expect(generatedSchema).toEqual({
-				enumStringType: {
-					description: 'Enum string type.',
-					enum: ['One', 'Two', 'Three', 'Four', 'Five'],
-					type: 'string',
-				},
-				enumValueType: {
-					description: 'Enum value type.',
-					enum: [
-						{
-							text: 'One',
-							value: 1,
-						},
-						{
-							text: 'Two',
-							value: 2,
-						},
-						{
-							text: 'Three',
-							value: 3,
-						},
-						{
-							text: 'Four',
-							value: 4,
-						},
-						{
-							text: 'Five',
-							value: 5,
-						},
-					],
-					type: 'integer',
-				},
-			});
-		});
-
-		test('It should concatenate arrays by request.', () => {
-			const generatedSchema = generateInputSchema({
-				schema: fullSchema,
-				keys: {
-					enumStringType: {
-						enum: ['Four', 'Five'],
-					},
-					enumValueType: {
-						enum: [
-							{
-								text: 'Four',
-								value: 4,
-							},
-							{
-								text: 'Five',
-								value: 5,
+								text: 'Three',
+								value: 3,
 							},
 						],
 					},
 				},
 				operation: 'arrayConcatenate',
-				arrayMergeType: 'concatenate',
 			});
 			expect(generatedSchema).toEqual({
 				enumStringType: {
 					description: 'Enum string type.',
-					enum: ['One', 'Two', 'Three', 'Four', 'Five'],
+					enum: ['One', 'Two', 'Three', 'Three', 'Four'],
 					type: 'string',
 				},
 				enumValueType: {
@@ -122,8 +64,8 @@ describe('Generate input schemas', () => {
 							value: 4,
 						},
 						{
-							text: 'Five',
-							value: 5,
+							text: 'Three',
+							value: 3,
 						},
 					],
 					type: 'integer',
@@ -136,13 +78,13 @@ describe('Generate input schemas', () => {
 				schema: fullSchema,
 				keys: {
 					enumStringType: {
-						enum: ['Four', 'Five'],
+						enum: ['Two', 'Five'],
 					},
 					enumValueType: {
 						enum: [
 							{
-								text: 'Four',
-								value: 4,
+								text: 'One',
+								value: 1,
 							},
 							{
 								text: 'Five',
@@ -157,15 +99,15 @@ describe('Generate input schemas', () => {
 			expect(generatedSchema).toEqual({
 				enumStringType: {
 					description: 'Enum string type.',
-					enum: ['Four', 'Five'],
+					enum: ['Two', 'Five'],
 					type: 'string',
 				},
 				enumValueType: {
 					description: 'Enum value type.',
 					enum: [
 						{
-							text: 'Four',
-							value: 4,
+							text: 'One',
+							value: 1,
 						},
 						{
 							text: 'Five',
@@ -177,22 +119,20 @@ describe('Generate input schemas', () => {
 			});
 		});
 
-		test('It should combine arrays by request.', () => {
+		test('It should index combine arrays by request.', () => {
 			const generatedSchema = generateInputSchema({
 				schema: fullSchema,
 				keys: {
 					enumStringType: {
-						enum: ['Four', 'Five'],
+						enum: ['Three', 'Four'],
 					},
 					enumValueType: {
 						enum: [
 							{
-								text: 'Four',
 								value: 4,
 							},
 							{
 								text: 'Five',
-								value: 5,
 							},
 						],
 					},
@@ -203,23 +143,80 @@ describe('Generate input schemas', () => {
 			expect(generatedSchema).toEqual({
 				enumStringType: {
 					description: 'Enum string type.',
-					enum: ['One', 'Two', 'Three', 'Four', 'Five'],
+					enum: ['One', 'Two', 'Three', 'Four'],
 					type: 'string',
 				},
 				enumValueType: {
 					description: 'Enum value type.',
 					enum: [
 						{
-							text: 'Four',
+							text: 'One',
 							value: 4,
 						},
 						{
 							text: 'Five',
-							value: 5,
+							value: 2,
 						},
 						{
 							text: 'Three',
 							value: 3,
+						},
+					],
+					type: 'integer',
+				},
+			});
+		});
+
+		test('It should hard index combine arrays by request.', () => {
+			const generatedSchema = generateInputSchema({
+				schema: fullSchema,
+				keys: {
+					enumStringType: {
+						enum: ['Three', 'Four'],
+					},
+					enumValueType: {
+						enum: [
+							{},
+							{
+								text: 'Five',
+							},
+							{
+								value: { key: 'value' },
+							},
+							{
+								text: 'Five',
+								value: 1,
+							},
+						],
+					},
+				},
+				operation: 'arrayCombine',
+				arrayMergeType: 'hardCombine',
+			});
+			expect(generatedSchema).toEqual({
+				enumStringType: {
+					description: 'Enum string type.',
+					enum: ['Three', 'Four', 'Three'],
+					type: 'string',
+				},
+				enumValueType: {
+					description: 'Enum value type.',
+					enum: [
+						{
+							text: 'One',
+							value: 1,
+						},
+						{
+							text: 'Five',
+							value: 2,
+						},
+						{
+							text: 'Three',
+							value: { key: 'value' },
+						},
+						{
+							text: 'Five',
+							value: 1,
 						},
 					],
 					type: 'integer',

--- a/tests/methods/schema/arrayMerge.test.js
+++ b/tests/methods/schema/arrayMerge.test.js
@@ -1,0 +1,230 @@
+// merge types
+// concatenate (default) (concatenate)
+// object (combine by index position) (combine)
+// replace (overwrite completely) (overwrite)
+const { generateInputSchema } = require('../../../lib/index');
+const { fullSchema } = require('./schema');
+const { mockConsole, restoreConsole } = require('./console');
+
+describe('Generate input schemas', () => {
+	beforeEach(() => {
+		mockConsole();
+	});
+
+	afterEach(() => {
+		restoreConsole();
+	});
+
+	describe('Array merge', () => {
+		test('It should concatenate arrays by default.', () => {
+			const generatedSchema = generateInputSchema({
+				schema: fullSchema,
+				keys: {
+					enumStringType: {
+						enum: ['Four', 'Five'],
+					},
+					enumValueType: {
+						enum: [
+							{
+								text: 'Four',
+								value: 4,
+							},
+							{
+								text: 'Five',
+								value: 5,
+							},
+						],
+					},
+				},
+				operation: 'arrayConcatenateDefault',
+			});
+			expect(generatedSchema).toEqual({
+				enumStringType: {
+					description: 'Enum string type.',
+					enum: ['One', 'Two', 'Three', 'Four', 'Five'],
+					type: 'string',
+				},
+				enumValueType: {
+					description: 'Enum value type.',
+					enum: [
+						{
+							text: 'One',
+							value: 1,
+						},
+						{
+							text: 'Two',
+							value: 2,
+						},
+						{
+							text: 'Three',
+							value: 3,
+						},
+						{
+							text: 'Four',
+							value: 4,
+						},
+						{
+							text: 'Five',
+							value: 5,
+						},
+					],
+					type: 'integer',
+				},
+			});
+		});
+
+		test('It should concatenate arrays by request.', () => {
+			const generatedSchema = generateInputSchema({
+				schema: fullSchema,
+				keys: {
+					enumStringType: {
+						enum: ['Four', 'Five'],
+					},
+					enumValueType: {
+						enum: [
+							{
+								text: 'Four',
+								value: 4,
+							},
+							{
+								text: 'Five',
+								value: 5,
+							},
+						],
+					},
+				},
+				operation: 'arrayConcatenate',
+				arrayMergeType: 'concatenate',
+			});
+			expect(generatedSchema).toEqual({
+				enumStringType: {
+					description: 'Enum string type.',
+					enum: ['One', 'Two', 'Three', 'Four', 'Five'],
+					type: 'string',
+				},
+				enumValueType: {
+					description: 'Enum value type.',
+					enum: [
+						{
+							text: 'One',
+							value: 1,
+						},
+						{
+							text: 'Two',
+							value: 2,
+						},
+						{
+							text: 'Three',
+							value: 3,
+						},
+						{
+							text: 'Four',
+							value: 4,
+						},
+						{
+							text: 'Five',
+							value: 5,
+						},
+					],
+					type: 'integer',
+				},
+			});
+		});
+
+		test('It should overwrite arrays by request.', () => {
+			const generatedSchema = generateInputSchema({
+				schema: fullSchema,
+				keys: {
+					enumStringType: {
+						enum: ['Four', 'Five'],
+					},
+					enumValueType: {
+						enum: [
+							{
+								text: 'Four',
+								value: 4,
+							},
+							{
+								text: 'Five',
+								value: 5,
+							},
+						],
+					},
+				},
+				operation: 'arrayOverwrite',
+				arrayMergeType: 'overwrite',
+			});
+			expect(generatedSchema).toEqual({
+				enumStringType: {
+					description: 'Enum string type.',
+					enum: ['Four', 'Five'],
+					type: 'string',
+				},
+				enumValueType: {
+					description: 'Enum value type.',
+					enum: [
+						{
+							text: 'Four',
+							value: 4,
+						},
+						{
+							text: 'Five',
+							value: 5,
+						},
+					],
+					type: 'integer',
+				},
+			});
+		});
+
+		test('It should combine arrays by request.', () => {
+			const generatedSchema = generateInputSchema({
+				schema: fullSchema,
+				keys: {
+					enumStringType: {
+						enum: ['Four', 'Five'],
+					},
+					enumValueType: {
+						enum: [
+							{
+								text: 'Four',
+								value: 4,
+							},
+							{
+								text: 'Five',
+								value: 5,
+							},
+						],
+					},
+				},
+				operation: 'arrayCombine',
+				arrayMergeType: 'combine',
+			});
+			expect(generatedSchema).toEqual({
+				enumStringType: {
+					description: 'Enum string type.',
+					enum: ['One', 'Two', 'Three', 'Four', 'Five'],
+					type: 'string',
+				},
+				enumValueType: {
+					description: 'Enum value type.',
+					enum: [
+						{
+							text: 'Four',
+							value: 4,
+						},
+						{
+							text: 'Five',
+							value: 5,
+						},
+						{
+							text: 'Three',
+							value: 3,
+						},
+					],
+					type: 'integer',
+				},
+			});
+		});
+	});
+});

--- a/tests/methods/schema/arrayMerge.test.js
+++ b/tests/methods/schema/arrayMerge.test.js
@@ -26,12 +26,12 @@ describe('Generate input schemas', () => {
 					enumValueType: {
 						enum: [
 							{
-								text: 'Four',
-								value: 4,
-							},
-							{
 								text: 'Three',
 								value: 3,
+							},
+							{
+								text: 'Four',
+								value: 4,
 							},
 						],
 					},
@@ -60,12 +60,12 @@ describe('Generate input schemas', () => {
 							value: 3,
 						},
 						{
-							text: 'Four',
-							value: 4,
-						},
-						{
 							text: 'Three',
 							value: 3,
+						},
+						{
+							text: 'Four',
+							value: 4,
 						},
 					],
 					type: 'integer',
@@ -124,7 +124,7 @@ describe('Generate input schemas', () => {
 				schema: fullSchema,
 				keys: {
 					enumStringType: {
-						enum: ['Three', 'Four'],
+						enum: ['Two', 'Four', 'One', 'Five'],
 					},
 					enumValueType: {
 						enum: [
@@ -138,12 +138,12 @@ describe('Generate input schemas', () => {
 					},
 				},
 				operation: 'arrayCombine',
-				arrayMergeType: 'combine',
+				arrayMergeType: 'mergeCombineByIndex',
 			});
 			expect(generatedSchema).toEqual({
 				enumStringType: {
 					description: 'Enum string type.',
-					enum: ['One', 'Two', 'Three', 'Four'],
+					enum: ['One', 'Two', 'Three', 'Four', 'Five'],
 					type: 'string',
 				},
 				enumValueType: {
@@ -167,7 +167,7 @@ describe('Generate input schemas', () => {
 			});
 		});
 
-		test('It should hard index combine arrays by request.', () => {
+		test('It should index overwrite arrays by request.', () => {
 			const generatedSchema = generateInputSchema({
 				schema: fullSchema,
 				keys: {
@@ -191,7 +191,7 @@ describe('Generate input schemas', () => {
 					},
 				},
 				operation: 'arrayCombine',
-				arrayMergeType: 'hardCombine',
+				arrayMergeType: 'mergeOverwriteByIndex',
 			});
 			expect(generatedSchema).toEqual({
 				enumStringType: {

--- a/tests/methods/schema/arrayMerge.test.js
+++ b/tests/methods/schema/arrayMerge.test.js
@@ -138,7 +138,7 @@ describe('Generate input schemas', () => {
 					},
 				},
 				operation: 'arrayCombine',
-				arrayMergeType: 'mergeCombineByIndex',
+				arrayMergeType: 'combineByIndex',
 			});
 			expect(generatedSchema).toEqual({
 				enumStringType: {
@@ -191,7 +191,7 @@ describe('Generate input schemas', () => {
 					},
 				},
 				operation: 'arrayCombine',
-				arrayMergeType: 'mergeOverwriteByIndex',
+				arrayMergeType: 'overwriteByIndex',
 			});
 			expect(generatedSchema).toEqual({
 				enumStringType: {

--- a/tests/methods/schema/console.js
+++ b/tests/methods/schema/console.js
@@ -1,0 +1,22 @@
+/* eslint-disable no-console */
+const originalConsoleError = console.error;
+const originalConsoleTable = console.table;
+const originalConsoleWarn = console.warn;
+
+const mockedConsoleError = () => jest.fn();
+const mockedConsoleTable = () => jest.fn();
+const mockedConsoleWarn = () => jest.fn();
+
+module.exports = {
+	mockConsole: () => {
+		console.error = mockedConsoleError;
+		console.table = mockedConsoleTable;
+		console.warn = mockedConsoleWarn;
+	},
+
+	restoreConsole: () => {
+		console.error = originalConsoleError;
+		console.table = originalConsoleTable;
+		console.warn = originalConsoleWarn;
+	},
+};

--- a/tests/methods/schema/copy.test.js
+++ b/tests/methods/schema/copy.test.js
@@ -33,7 +33,7 @@ describe('Generate input schemas', () => {
 			schema = generateInputSchema({
 				schema: fullSchema,
 				keys: fullSchemaInput,
-				operation: 'testOp',
+				operation: 'copySchema',
 			});
 		});
 

--- a/tests/methods/schema/copy.test.js
+++ b/tests/methods/schema/copy.test.js
@@ -19,6 +19,7 @@ describe('Generate input schemas', () => {
 		enumValueType: {},
 		integerType: {},
 		missingDescription: {},
+		missingFullStop: {},
 		missingType: {},
 		numberType: {},
 		objectType: {},

--- a/tests/methods/schema/copy.test.js
+++ b/tests/methods/schema/copy.test.js
@@ -1,0 +1,75 @@
+const { generateInputSchema } = require('../../../lib/index');
+const { arrayType, fullSchema } = require('./schema');
+const { mockConsole, restoreConsole } = require('./console');
+
+describe('Generate input schemas', () => {
+	beforeEach(() => {
+		mockConsole();
+	});
+
+	afterEach(() => {
+		restoreConsole();
+	});
+
+	const fullSchemaInput = {
+		arrayType: {},
+		booleanType: {},
+		dateType: {},
+		enumStringType: {},
+		enumValueType: {},
+		integerType: {},
+		missingDescription: {},
+		missingType: {},
+		numberType: {},
+		objectType: {},
+		oneOfType: {},
+		stringType: {},
+	};
+
+	let schema;
+
+	describe('Copy schema elements', () => {
+		beforeEach(() => {
+			schema = generateInputSchema({
+				schema: fullSchema,
+				keys: fullSchemaInput,
+				operation: 'testOp',
+			});
+		});
+
+		test('It should not modify the schema elements', () => {
+			expect(schema).not.toBe(fullSchema);
+			expect(schema).toEqual(fullSchema);
+		});
+
+		test.each([
+			['array'],
+			['boolean'],
+			['date'],
+			['integer'],
+			['number'],
+			['object'],
+			['oneOf'],
+			['string'],
+		])('It should copy %s types', key => {
+			const type = `${key}Type`;
+			expect(schema[type]).not.toBe(fullSchema[type]);
+			expect(schema[type]).toEqual(fullSchema[type]);
+		});
+
+		test('It should deep copy child objects', () => {
+			expect(schema.arrayType.items.properties.child).not.toBe(
+				fullSchema.arrayType.items.properties.child,
+			);
+			expect(schema.arrayType.items.properties.child).not.toBe(
+				arrayType.items.properties.child,
+			);
+			expect(schema.arrayType.items.properties.child).toEqual(
+				fullSchema.arrayType.items.properties.child,
+			);
+			expect(schema.arrayType.items.properties.child).toEqual(
+				arrayType.items.properties.child,
+			);
+		});
+	});
+});

--- a/tests/methods/schema/generate.test.js
+++ b/tests/methods/schema/generate.test.js
@@ -18,7 +18,7 @@ describe('Generate input schemas', () => {
 				keys: {
 					objectType: {},
 				},
-				operation: 'testRequestKey',
+				operation: 'generateByKey',
 			});
 			expect(generatedSchema).toEqual({
 				objectType: {
@@ -58,7 +58,7 @@ describe('Generate input schemas', () => {
 						},
 					},
 				},
-				operation: 'testRequestKeyWithOverrides',
+				operation: 'generateByKeyWithDeepMerge',
 			});
 			expect(generatedSchema).toEqual({
 				objectType: {

--- a/tests/methods/schema/generate.test.js
+++ b/tests/methods/schema/generate.test.js
@@ -1,0 +1,87 @@
+const { generateInputSchema } = require('../../../lib/index');
+const { fullSchema } = require('./schema');
+const { mockConsole, restoreConsole } = require('./console');
+
+describe('Generate input schemas', () => {
+	beforeEach(() => {
+		mockConsole();
+	});
+
+	afterEach(() => {
+		restoreConsole();
+	});
+
+	describe('Generate schemas', () => {
+		test('It should generate schema from requested key.', () => {
+			const generatedSchema = generateInputSchema({
+				schema: fullSchema,
+				keys: {
+					objectType: {},
+				},
+				operation: 'testRequestKey',
+			});
+			expect(generatedSchema).toEqual({
+				objectType: {
+					type: 'object',
+					title: 'Parent',
+					properties: {
+						name: {
+							type: 'string',
+						},
+						child: {
+							title: 'child',
+							properties: {
+								name: { type: 'string' },
+							},
+						},
+					},
+					additionalProperties: false,
+				},
+			});
+		});
+
+		test('It should generate schema with deep merge.', () => {
+			const generatedSchema = generateInputSchema({
+				schema: fullSchema,
+				keys: {
+					objectType: {
+						properties: {
+							child: {
+								description: 'Child description.',
+								properties: {
+									name: {
+										type: 'boolean',
+										default: true,
+									},
+								},
+							},
+						},
+					},
+				},
+				operation: 'testRequestKeyWithOverrides',
+			});
+			expect(generatedSchema).toEqual({
+				objectType: {
+					type: 'object',
+					title: 'Parent',
+					properties: {
+						name: {
+							type: 'string',
+						},
+						child: {
+							title: 'child',
+							description: 'Child description.',
+							properties: {
+								name: {
+									type: 'boolean',
+									default: true,
+								},
+							},
+						},
+					},
+					additionalProperties: false,
+				},
+			});
+		});
+	});
+});

--- a/tests/methods/schema/override.test.js
+++ b/tests/methods/schema/override.test.js
@@ -18,7 +18,7 @@ describe('Generate input schemas', () => {
 				keys: {
 					override: { type: 'string', description: 'Description.' },
 				},
-				operation: 'testFullOverride',
+				operation: 'fullOverride',
 			});
 			expect(generatedSchema).toEqual({
 				override: {
@@ -37,7 +37,7 @@ describe('Generate input schemas', () => {
 						description: 'Date time override.',
 					},
 				},
-				operation: 'testRequestKeyWithOverrides',
+				operation: 'keyWithTopLevelOverrides',
 			});
 			expect(generatedSchema).toEqual({
 				dateType: {
@@ -67,7 +67,7 @@ describe('Generate input schemas', () => {
 						},
 					},
 				},
-				operation: 'testRequestKeyWithOverrides',
+				operation: 'keyWithDeepOverrides',
 			});
 			expect(generatedSchema).toEqual({
 				objectType: {

--- a/tests/methods/schema/override.test.js
+++ b/tests/methods/schema/override.test.js
@@ -1,0 +1,96 @@
+const { generateInputSchema } = require('../../../lib/index');
+const { fullSchema } = require('./schema');
+const { mockConsole, restoreConsole } = require('./console');
+
+describe('Generate input schemas', () => {
+	beforeEach(() => {
+		mockConsole();
+	});
+
+	afterEach(() => {
+		restoreConsole();
+	});
+
+	describe('Overrides', () => {
+		test('It should generate schema from overrides only.', () => {
+			const generatedSchema = generateInputSchema({
+				schema: fullSchema,
+				keys: {
+					override: { type: 'string', description: 'Description.' },
+				},
+				operation: 'testFullOverride',
+			});
+			expect(generatedSchema).toEqual({
+				override: {
+					description: 'Description.',
+					type: 'string',
+				},
+			});
+		});
+
+		test('It should generate schema from requested key with overrides.', () => {
+			const generatedSchema = generateInputSchema({
+				schema: fullSchema,
+				keys: {
+					dateType: {
+						type: 'string',
+						description: 'Date time override.',
+					},
+				},
+				operation: 'testRequestKeyWithOverrides',
+			});
+			expect(generatedSchema).toEqual({
+				dateType: {
+					date_mask: 'X',
+					description: 'Date time override.',
+					format: 'datetime',
+					type: 'string',
+				},
+			});
+		});
+
+		test('It should generate schema with deep merge override.', () => {
+			const generatedSchema = generateInputSchema({
+				schema: fullSchema,
+				keys: {
+					objectType: {
+						properties: {
+							child: {
+								description: 'Child description.',
+								properties: {
+									name: {
+										type: 'boolean',
+										default: true,
+									},
+								},
+							},
+						},
+					},
+				},
+				operation: 'testRequestKeyWithOverrides',
+			});
+			expect(generatedSchema).toEqual({
+				objectType: {
+					type: 'object',
+					title: 'Parent',
+					properties: {
+						name: {
+							type: 'string',
+						},
+						child: {
+							title: 'child',
+							description: 'Child description.',
+							properties: {
+								name: {
+									type: 'boolean',
+									default: true,
+								},
+							},
+						},
+					},
+					additionalProperties: false,
+				},
+			});
+		});
+	});
+});

--- a/tests/methods/schema/schema.js
+++ b/tests/methods/schema/schema.js
@@ -53,8 +53,13 @@ const missingDescription = {
 	type: 'integer',
 };
 
+const missingFullStop = {
+	type: 'string',
+	description: 'When in Rome, kill me',
+};
+
 const missingType = {
-	description: 'The type is missing',
+	description: 'The type is missing.',
 };
 
 const numberType = {
@@ -130,6 +135,7 @@ const fullSchema = {
 	enumValueType,
 	integerType,
 	missingDescription,
+	missingFullStop,
 	missingType,
 	numberType,
 	objectType,
@@ -146,6 +152,7 @@ module.exports = {
 	fullSchema,
 	integerType,
 	missingDescription,
+	missingFullStop,
 	missingType,
 	numberType,
 	objectType,

--- a/tests/methods/schema/schema.js
+++ b/tests/methods/schema/schema.js
@@ -1,0 +1,154 @@
+const arrayType = {
+	type: 'array',
+	items: {
+		type: 'object',
+		title: 'Parent',
+		description: 'Array type.',
+		properties: {
+			name: {
+				type: 'string',
+			},
+			child: {
+				type: 'object',
+				title: 'child',
+				properties: {
+					name: { type: 'string' },
+				},
+			},
+		},
+	},
+	additionalItems: true,
+};
+
+const booleanType = {
+	type: 'boolean',
+};
+
+const dateType = {
+	format: 'datetime',
+	date_mask: 'X',
+};
+
+const enumStringType = {
+	type: 'string',
+	description: 'Enum string type.',
+	enum: ['One', 'Two', 'Three'],
+};
+
+const enumValueType = {
+	type: 'integer',
+	description: 'Enum value type.',
+	enum: [
+		{ text: 'One', value: 1 },
+		{ text: 'Two', value: 2 },
+		{ text: 'Three', value: 3 },
+	],
+};
+
+const integerType = {
+	type: 'integer',
+};
+
+const missingDescription = {
+	type: 'integer',
+};
+
+const missingType = {
+	description: 'The type is missing',
+};
+
+const numberType = {
+	type: 'number',
+	default: 5,
+};
+
+const objectType = {
+	type: 'object',
+	title: 'Parent',
+	properties: {
+		name: {
+			type: 'string',
+		},
+		child: {
+			title: 'child',
+			properties: {
+				name: { type: 'string' },
+			},
+		},
+	},
+	additionalProperties: false,
+};
+
+const oneOfType = {
+	title: 'OneOf',
+	description: 'OneOf type.',
+	oneOf: [
+		{
+			title: 'Option one',
+			type: 'object',
+			properties: {
+				user_id: {
+					title: 'Option one',
+					type: 'string',
+					lookup: {
+						step_settings: {
+							company_id: {
+								type: 'integer',
+								value: '{{{properties.company_id}}}',
+							},
+						},
+					},
+					required: true,
+				},
+			},
+		},
+		{
+			title: 'Option two',
+			type: 'object',
+			properties: {
+				account_id: {
+					title: 'Option two',
+					type: 'string',
+					lookup: {},
+					required: true,
+				},
+			},
+		},
+	],
+};
+
+const stringType = {
+	type: 'string',
+	required: true,
+};
+
+const fullSchema = {
+	arrayType,
+	booleanType,
+	dateType,
+	enumStringType,
+	enumValueType,
+	integerType,
+	missingDescription,
+	missingType,
+	numberType,
+	objectType,
+	oneOfType,
+	stringType,
+};
+
+module.exports = {
+	arrayType,
+	booleanType,
+	dateType,
+	enumStringType,
+	enumValueType,
+	fullSchema,
+	integerType,
+	missingDescription,
+	missingType,
+	numberType,
+	objectType,
+	oneOfType,
+	stringType,
+};

--- a/tests/methods/schema/validate.test.js
+++ b/tests/methods/schema/validate.test.js
@@ -3,8 +3,8 @@ const { generateInputSchema } = require('../../../lib/index');
 
 const { arrayType, fullSchema } = require('./schema');
 
-const MISSING_KEYS_MESSAGE =
-	'There are missing schema keys that should be provided:';
+const INPUT_SCHEMA_PROBLEMS_MESSAGE =
+	'There are problems with the generated input schema:';
 
 const originalConsoleError = console.error;
 const originalConsoleTable = console.table;
@@ -42,6 +42,7 @@ describe('Generate input schemas', () => {
 		enumValueType: {},
 		integerType: {},
 		missingDescription: {},
+		missingFullStop: {},
 		missingType: {},
 		numberType: {},
 		objectType: {},
@@ -58,7 +59,7 @@ describe('Generate input schemas', () => {
 				},
 				operation: 'validateArrayType',
 			});
-			expect(consoleErrorOutput).toEqual([MISSING_KEYS_MESSAGE]);
+			expect(consoleErrorOutput).toEqual([INPUT_SCHEMA_PROBLEMS_MESSAGE]);
 			expect(consoleTableOutput).toEqual([
 				[
 					{
@@ -79,7 +80,7 @@ describe('Generate input schemas', () => {
 				keys: { missingType: {} },
 				operation: 'validateMissingType',
 			});
-			expect(consoleErrorOutput).toEqual([MISSING_KEYS_MESSAGE]);
+			expect(consoleErrorOutput).toEqual([INPUT_SCHEMA_PROBLEMS_MESSAGE]);
 			expect(consoleTableOutput).toEqual([
 				[
 					{
@@ -96,12 +97,29 @@ describe('Generate input schemas', () => {
 				keys: { missingDescription: {} },
 				operation: 'validateMissingDescription',
 			});
-			expect(consoleWarnOutput).toEqual([MISSING_KEYS_MESSAGE]);
+			expect(consoleWarnOutput).toEqual([INPUT_SCHEMA_PROBLEMS_MESSAGE]);
 			expect(consoleTableOutput).toEqual([
 				[
 					{
 						key: 'validateMissingDescription.missingDescription',
 						description: 'missing',
+					},
+				],
+			]);
+		});
+
+		test('It should log if the description is missing a full stop.', () => {
+			generateInputSchema({
+				schema: fullSchema,
+				keys: { missingFullStop: {} },
+				operation: 'validateMissingFullStop',
+			});
+			expect(consoleWarnOutput).toEqual([INPUT_SCHEMA_PROBLEMS_MESSAGE]);
+			expect(consoleTableOutput).toEqual([
+				[
+					{
+						key: 'validateMissingFullStop.missingFullStop',
+						'full stop': 'missing',
 					},
 				],
 			]);
@@ -117,7 +135,7 @@ describe('Generate input schemas', () => {
 				},
 				operation: 'validateMissingOverrideType',
 			});
-			expect(consoleErrorOutput).toEqual([MISSING_KEYS_MESSAGE]);
+			expect(consoleErrorOutput).toEqual([INPUT_SCHEMA_PROBLEMS_MESSAGE]);
 			expect(consoleTableOutput).toEqual([
 				[
 					{
@@ -134,7 +152,7 @@ describe('Generate input schemas', () => {
 				keys: { override: { type: 'string' } },
 				operation: 'validateMissingOverrideDescription',
 			});
-			expect(consoleWarnOutput).toEqual([MISSING_KEYS_MESSAGE]);
+			expect(consoleWarnOutput).toEqual([INPUT_SCHEMA_PROBLEMS_MESSAGE]);
 			expect(consoleTableOutput).toEqual([
 				[
 					{
@@ -166,7 +184,7 @@ describe('Generate input schemas', () => {
 				keys: fullSchemaInput,
 				operation: 'validateFullSchema',
 			});
-			expect(consoleErrorOutput).toEqual([MISSING_KEYS_MESSAGE]);
+			expect(consoleErrorOutput).toEqual([INPUT_SCHEMA_PROBLEMS_MESSAGE]);
 			expect(consoleTableOutput).toEqual([
 				[
 					{
@@ -207,6 +225,10 @@ describe('Generate input schemas', () => {
 					{
 						description: 'missing',
 						key: 'validateFullSchema.missingDescription',
+					},
+					{
+						key: 'validateFullSchema.missingFullStop',
+						'full stop': 'missing',
 					},
 					{
 						key: 'validateFullSchema.missingType',

--- a/tests/methods/schema/validate.test.js
+++ b/tests/methods/schema/validate.test.js
@@ -56,18 +56,18 @@ describe('Generate input schemas', () => {
 				keys: {
 					thisKeyDoesNotExist: {},
 				},
-				operation: 'testArrayType',
+				operation: 'validateArrayType',
 			});
 			expect(consoleErrorOutput).toEqual([MISSING_KEYS_MESSAGE]);
 			expect(consoleTableOutput).toEqual([
 				[
 					{
-						key: 'testArrayType.thisKeyDoesNotExist',
+						key: 'validateArrayType.thisKeyDoesNotExist',
 						type: 'missing',
 					},
 					{
 						description: 'missing',
-						key: 'testArrayType.thisKeyDoesNotExist',
+						key: 'validateArrayType.thisKeyDoesNotExist',
 					},
 				],
 			]);
@@ -77,13 +77,13 @@ describe('Generate input schemas', () => {
 			generateInputSchema({
 				schema: fullSchema,
 				keys: { missingType: {} },
-				operation: 'testMissingType',
+				operation: 'validateMissingType',
 			});
 			expect(consoleErrorOutput).toEqual([MISSING_KEYS_MESSAGE]);
 			expect(consoleTableOutput).toEqual([
 				[
 					{
-						key: 'testMissingType.missingType',
+						key: 'validateMissingType.missingType',
 						type: 'missing',
 					},
 				],
@@ -94,13 +94,13 @@ describe('Generate input schemas', () => {
 			generateInputSchema({
 				schema: fullSchema,
 				keys: { missingDescription: {} },
-				operation: 'testMissingDescription',
+				operation: 'validateMissingDescription',
 			});
 			expect(consoleWarnOutput).toEqual([MISSING_KEYS_MESSAGE]);
 			expect(consoleTableOutput).toEqual([
 				[
 					{
-						key: 'testMissingDescription.missingDescription',
+						key: 'validateMissingDescription.missingDescription',
 						description: 'missing',
 					},
 				],
@@ -115,14 +115,14 @@ describe('Generate input schemas', () => {
 						description: 'Override type is missing.',
 					},
 				},
-				operation: 'testMissingOverrideType',
+				operation: 'validateMissingOverrideType',
 			});
 			expect(consoleErrorOutput).toEqual([MISSING_KEYS_MESSAGE]);
 			expect(consoleTableOutput).toEqual([
 				[
 					{
 						type: 'missing',
-						key: 'testMissingOverrideType.override',
+						key: 'validateMissingOverrideType.override',
 					},
 				],
 			]);
@@ -132,14 +132,14 @@ describe('Generate input schemas', () => {
 			generateInputSchema({
 				schema: fullSchema,
 				keys: { override: { type: 'string' } },
-				operation: 'testMissingOverrideDescription',
+				operation: 'validateMissingOverrideDescription',
 			});
 			expect(consoleWarnOutput).toEqual([MISSING_KEYS_MESSAGE]);
 			expect(consoleTableOutput).toEqual([
 				[
 					{
 						description: 'missing',
-						key: 'testMissingOverrideDescription.override',
+						key: 'validateMissingOverrideDescription.override',
 					},
 				],
 			]);
@@ -154,7 +154,7 @@ describe('Generate input schemas', () => {
 						description: 'Description.',
 					},
 				},
-				operation: 'testFullOverride',
+				operation: 'validateFullOverride',
 			});
 			expect(consoleWarnOutput).toEqual([]);
 			expect(consoleTableOutput).toEqual([]);
@@ -164,90 +164,92 @@ describe('Generate input schemas', () => {
 			generateInputSchema({
 				schema: fullSchema,
 				keys: fullSchemaInput,
-				operation: 'testFullSchema',
+				operation: 'validateFullSchema',
 			});
 			expect(consoleErrorOutput).toEqual([MISSING_KEYS_MESSAGE]);
 			expect(consoleTableOutput).toEqual([
 				[
 					{
 						description: 'missing',
-						key: 'testFullSchema.arrayType',
-					},
-					{
-						description: 'missing',
-						key: 'testFullSchema.arrayType.items.properties.name',
-					},
-					{
-						description: 'missing',
-						key: 'testFullSchema.arrayType.items.properties.child',
+						key: 'validateFullSchema.arrayType',
 					},
 					{
 						description: 'missing',
 						key:
-							'testFullSchema.arrayType.items.properties.child.properties.name',
+							'validateFullSchema.arrayType.items.properties.name',
 					},
 					{
 						description: 'missing',
-						key: 'testFullSchema.booleanType',
+						key:
+							'validateFullSchema.arrayType.items.properties.child',
 					},
 					{
-						key: 'testFullSchema.dateType',
+						description: 'missing',
+						key:
+							'validateFullSchema.arrayType.items.properties.child.properties.name',
+					},
+					{
+						description: 'missing',
+						key: 'validateFullSchema.booleanType',
+					},
+					{
+						key: 'validateFullSchema.dateType',
 						type: 'missing',
 					},
 					{
 						description: 'missing',
-						key: 'testFullSchema.dateType',
+						key: 'validateFullSchema.dateType',
 					},
 					{
 						description: 'missing',
-						key: 'testFullSchema.integerType',
+						key: 'validateFullSchema.integerType',
 					},
 					{
 						description: 'missing',
-						key: 'testFullSchema.missingDescription',
+						key: 'validateFullSchema.missingDescription',
 					},
 					{
-						key: 'testFullSchema.missingType',
+						key: 'validateFullSchema.missingType',
 						type: 'missing',
 					},
 					{
 						description: 'missing',
-						key: 'testFullSchema.numberType',
+						key: 'validateFullSchema.numberType',
 					},
 					{
 						description: 'missing',
-						key: 'testFullSchema.objectType',
+						key: 'validateFullSchema.objectType',
 					},
 					{
 						description: 'missing',
-						key: 'testFullSchema.objectType.properties.name',
+						key: 'validateFullSchema.objectType.properties.name',
 					},
 					{
-						key: 'testFullSchema.objectType.properties.child',
+						key: 'validateFullSchema.objectType.properties.child',
 						type: 'missing',
 					},
 					{
 						description: 'missing',
-						key: 'testFullSchema.objectType.properties.child',
+						key: 'validateFullSchema.objectType.properties.child',
 					},
 					{
 						description: 'missing',
 						key:
-							'testFullSchema.objectType.properties.child.properties.name',
+							'validateFullSchema.objectType.properties.child.properties.name',
 					},
 					{
 						description: 'missing',
 						key:
-							'testFullSchema.oneOfType.oneOf.properties.user_id',
+							'validateFullSchema.oneOfType.oneOf.properties.user_id',
 					},
 					{
 						description: 'missing',
 						key:
-							'testFullSchema.oneOfType.oneOf.properties.account_id',
+							'validateFullSchema.oneOfType.oneOf.properties.account_id',
 					},
 					{
 						description: 'missing',
-						key: 'testFullSchema.stringType',
+						key: 'validateFullSchema.stringType',
 					},
 				],
 			]);

--- a/tests/methods/validatePagination.test.js
+++ b/tests/methods/validatePagination.test.js
@@ -1,4 +1,4 @@
-const { validatePaginationRange } = require('../../');
+const { validatePaginationRange } = require('../..');
 
 const PAGE_SIZE = 50;
 const MIN_PAGE_SIZE = 1;


### PR DESCRIPTION
Fixes the following Jira issues:

[Deep Merge input schema overrides](https://trayio.atlassian.net/browse/CSP-3910)
[Verify full stops at end of descriptions](https://trayio.atlassian.net/browse/CSP-3911)
[Ability to alias input schema keys](https://trayio.atlassian.net/browse/CSP-4743)

Makes use of the [deepmerge](https://www.npmjs.com/package/deepmerge) npm library - [GitHub Repo](https://github.com/TehShrike/deepmerge)

Also, makes use of the [deepdash](https://deepdash.io/) library for omitting object keys at deeply nested levels.

