### PR TITLE
[CSP-4943] add hasValidEndingPunctuation, update tests, readme and schema_genera…

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,9 +429,9 @@ Will log to the console if:
 
 -   a requested key does not exist, or
 -   `type` or `description` keys are missing, or
--   a `description` does not end in a full stop
+-   a `description` does not end with valid punctuation
 
-Will not log to the console if requested key does not exist, but is overridden with at least a type and description with a full stop.
+Will not log to the console if requested key does not exist, but is overridden with at least a type and description ending with a valid punctuation mark.
 
 For more information on how to use the schema generator, please see [schema-generation.md](./schema-generation.md).
 

--- a/lib/generateInputSchema.js
+++ b/lib/generateInputSchema.js
@@ -22,7 +22,7 @@ const logIssuesToConsole = ({ issues }) => {
 			key: error.key,
 			[error.missing]: 'missing',
 		})),
-		['key', 'type', 'description', 'full stop'],
+		['key', 'type', 'description', 'ending punctuation'],
 	);
 };
 
@@ -86,6 +86,13 @@ const deepValidateSchema = ({ collection, iteratee, path = 'schema' }) => {
 	return flattenAndCompact({ array: issues });
 };
 
+// check if description ends in valid punctuation
+const hasValidEndingPunctuation = description => {
+	const validPunctuation = ['.', '?', '!']
+	const endingChar = description.slice(-1)
+	return validPunctuation.includes(endingChar)
+}
+
 // Schema elements must include 'type' and 'description' keys.
 const checkForIncompleteSchemaElements = ({ element, key }) => {
 	const keys = Object.keys(element);
@@ -96,8 +103,8 @@ const checkForIncompleteSchemaElements = ({ element, key }) => {
 		}
 		if (!keys.includes('description')) {
 			incompleteSchemaElements.push({ key, missing: 'description' });
-		} else if (!_.get(element, 'description', '.').endsWith('.')) {
-			incompleteSchemaElements.push({ key, missing: 'full stop' });
+		} else if (!hasValidEndingPunctuation(_.get(element, 'description', '.'))) {
+			incompleteSchemaElements.push({ key, missing: 'ending punctuation' });
 		}
 	}
 	return incompleteSchemaElements;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@trayio/connector-utils",
-	"version": "0.3.4",
+	"version": "0.3.5",
 	"description": "Common utility functions used in connectors.",
 	"main": "lib/index.js",
 	"scripts": {

--- a/schema-generation.md
+++ b/schema-generation.md
@@ -104,7 +104,7 @@ module.exports = {
 
 ## Logging Schema Issues
 
-The schema generator automatically checks the generated schema for issues. It will detect when `type` keys and `description` keys are missing. It will also report missing full stops in descriptions.
+The schema generator automatically checks the generated schema for issues. It will detect when `type` keys and `description` keys are missing. It will also report missing ending punctuation marks in descriptions.
 
 Issues are logged to the console whenever the schema is generated. In practice, this means that whenever you invoke the `test-runner` or `node-dev main.js` you will be able to see and fix schema issues.
 
@@ -122,7 +122,7 @@ When using `node-dev main.js`:
 
 ![Node-dev log](./img/node-dev-log.png)
 
-Missing `description`s and full stops are logged as warnings.
+Missing `description`s and ending punctuation marks are logged as warnings.
 
 This is really useful for catching and fixing QA issues (before they happen) where input tooltips are missing.
 

--- a/tests/methods/schema/validate.test.js
+++ b/tests/methods/schema/validate.test.js
@@ -108,7 +108,7 @@ describe('Generate input schemas', () => {
 			]);
 		});
 
-		test('It should log if the description is missing a full stop.', () => {
+		test('It should log if the description is missing a valid ending punctuation mark.', () => {
 			generateInputSchema({
 				schema: fullSchema,
 				keys: { missingFullStop: {} },
@@ -119,7 +119,7 @@ describe('Generate input schemas', () => {
 				[
 					{
 						key: 'validateMissingFullStop.missingFullStop',
-						'full stop': 'missing',
+						'ending punctuation': 'missing',
 					},
 				],
 			]);
@@ -228,7 +228,7 @@ describe('Generate input schemas', () => {
 					},
 					{
 						key: 'validateFullSchema.missingFullStop',
-						'full stop': 'missing',
+						'ending punctuation': 'missing',
 					},
 					{
 						key: 'validateFullSchema.missingType',

--- a/tests/methods/schema/validate.test.js
+++ b/tests/methods/schema/validate.test.js
@@ -178,6 +178,52 @@ describe('Generate input schemas', () => {
 			expect(consoleTableOutput).toEqual([]);
 		});
 
+		test('It should not log if the description ends with a full stop.', () => {
+			generateInputSchema({
+				schema: fullSchema,
+				keys: {
+					full_stop: {
+						type: 'string',
+						description: 'full stop.',
+					},
+				},
+				operation: 'validateFullStop',
+			});
+			expect(consoleWarnOutput).toEqual([]);
+			expect(consoleTableOutput).toEqual([]);
+		});
+
+		test('It should not log if the description ends with a question mark.', () => {
+			generateInputSchema({
+				schema: fullSchema,
+				keys: {
+					question_mark: {
+						type: 'string',
+						description: 'question mark?',
+					},
+				},
+				operation: 'validateQuestionMark',
+			});
+			expect(consoleWarnOutput).toEqual([]);
+			expect(consoleTableOutput).toEqual([]);
+		});
+
+		test('It should not log if the description ends with an exclamation mark.', () => {
+			generateInputSchema({
+				schema: fullSchema,
+				keys: {
+					exclamation_mark: {
+						type: 'string',
+						description: 'exclamation mark!',
+					},
+				},
+				operation: 'validateExclamationMark',
+			});
+			expect(consoleWarnOutput).toEqual([]);
+			expect(consoleTableOutput).toEqual([]);
+		});
+		
+
 		test('It should log all issue in full schema.', () => {
 			generateInputSchema({
 				schema: fullSchema,


### PR DESCRIPTION
the `generateInputSchema` util is warning for descriptions ending in '?' or '!' 

[linked issue](https://github.com/trayio/connector-utils/issues/53)

added hasValidEndingPunctuation and updated checkForIncompleteSchemaElements

also updated tests, readme and schema_generation.md :)