### PR TITLE
[CSP-4988] adding generatealltypes helper to connectors util

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,7 +526,7 @@ formatArrayToDelimitedList({ arrayToFormat: undefined });
 ## generateAllTypes({ exclude = '' })
 
 Helper for generating all available JSON schema types.
-You may use the "exclude" parameter to exclude any unwanted type 
+You may use the "exclude" parameter to exclude any unwanted type. 
 
 **Kind**: global function
 
@@ -539,9 +539,9 @@ You may use the "exclude" parameter to exclude any unwanted type
 ```js
 generateAllTypes({})
 
-// returns ['string','number', 'object','array','boolean','null']
+// returns ['string','number','object','array','boolean','null']
 
 generateAllTypes({exclude: 'null, boolean'})
 
-// returns ["string", "number", "object", "array"]
+// returns ['string','number','object','array']
 ```

--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ for arrays).</p>
 <dt><a href="#formatArrayToDelimitedList">formatArrayToDelimitedList({ arrayToFormat, [delimiter] })</a></dt>
 <dd><p>Helper to take an array of strings and return a string that is a list, delimited by the specified delimiter ('<code>,</code>' by default).</p>
 </dd>
+</dd>
+<dt><a href="#generateAnyType">generateAnyType({ exclude = '' })</a></dt>
+<dd><p>Helper for generating all available JSON schema types.</p>
+</dd>
 </dl>
 
 <a name="GenericError"></a>
@@ -515,4 +519,29 @@ formatArrayToDelimitedList({ arrayToFormat: inputArray });
 formatArrayToDelimitedList({ arrayToFormat: undefined });
 
 // returns undefined
+```
+
+<a name="generateAnyType"></a>
+
+## generateAnyType({ exclude = '' })
+
+Helper for generating all available JSON schema types.
+You may use the "exclude" parameter to exclude any unwanted type 
+
+**Kind**: global function
+
+| Param         | Type                | Default        | Description                                                                      |
+| ------------- | ------------------- | -------------- | -------------------------------------------------------------------------------- |
+| exclude | <code>String</code>  | <code>''</code> | String of types separated by comma to be excluded. |
+
+**Example**:
+
+```js
+generateAnyType({})
+
+// returns ['string','number', 'object','array','boolean','null']
+
+generateAnyType({exclude: 'null, boolean'})
+
+// returns ["string", "number", "object", "array"]
 ```

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ for arrays).</p>
 <dd><p>Helper to take an array of strings and return a string that is a list, delimited by the specified delimiter ('<code>,</code>' by default).</p>
 </dd>
 </dd>
-<dt><a href="#generateAnyType">generateAnyType({ exclude = '' })</a></dt>
+<dt><a href="#generateAllTypes">generateAllTypes({ exclude = '' })</a></dt>
 <dd><p>Helper for generating all available JSON schema types.</p>
 </dd>
 </dl>
@@ -521,9 +521,9 @@ formatArrayToDelimitedList({ arrayToFormat: undefined });
 // returns undefined
 ```
 
-<a name="generateAnyType"></a>
+<a name="generateAllTypes"></a>
 
-## generateAnyType({ exclude = '' })
+## generateAllTypes({ exclude = '' })
 
 Helper for generating all available JSON schema types.
 You may use the "exclude" parameter to exclude any unwanted type 
@@ -537,11 +537,11 @@ You may use the "exclude" parameter to exclude any unwanted type
 **Example**:
 
 ```js
-generateAnyType({})
+generateAllTypes({})
 
 // returns ['string','number', 'object','array','boolean','null']
 
-generateAnyType({exclude: 'null, boolean'})
+generateAllTypes({exclude: 'null, boolean'})
 
 // returns ["string", "number", "object", "array"]
 ```

--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -1,6 +1,6 @@
 const { UserInputError } = require('./errors');
 
-const setErrorMessage = input =>
+const setErrorMessage = (input) =>
 	`Expected an array but instead received input of type '${typeof input}'.`;
 
 /**
@@ -29,25 +29,7 @@ const formatArrayToDelimitedList = ({ arrayToFormat, delimiter = ',' }) => {
  * @return {String} Delimited string.
  */
 
-const formatArray = arrayToFormat =>
-    formatArrayToDelimitedList({ arrayToFormat });
+const formatArray = (arrayToFormat) =>
+	formatArrayToDelimitedList({ arrayToFormat });
 
-/** 
- * 
- * 
- * @param {String} [exclude=''] Types to be excluded separated by comma 
- * @return {Array} Array of string.
- */    
-    
-const generateAnyType = ({ exclude = '' }) => { 
-    if (typeof exclude !== 'string') {
-        throw new UserInputError('The type of "exclude" argument must be string.')
-     }
-    let anyType = ['string','number', 'object','array','boolean','null']
-    const excludedTypesArr = exclude.split(',').map(type => (type.trim()));
-    anyType =  anyType.filter(type => !excludedTypesArr.includes(type))
-    
-    return anyType
-}
-
-module.exports = { formatArrayToDelimitedList, formatArray, generateAnyType };
+module.exports = { formatArrayToDelimitedList, formatArray };

--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -30,6 +30,24 @@ const formatArrayToDelimitedList = ({ arrayToFormat, delimiter = ',' }) => {
  */
 
 const formatArray = arrayToFormat =>
-	formatArrayToDelimitedList({ arrayToFormat });
+    formatArrayToDelimitedList({ arrayToFormat });
 
-module.exports = { formatArrayToDelimitedList, formatArray };
+/** 
+ * 
+ * 
+ * @param {String} [exclude=''] Types to be excluded separated by comma 
+ * @return {Array} Array of string.
+ */    
+    
+const generateAnyType = ({ exclude = '' }) => { 
+    if (typeof exclude !== 'string') {
+        throw new UserInputError('The type of "exclude" argument must be string.')
+     }
+    let anyType = ['string','number', 'object','array','boolean','null']
+    const excludedTypesArr = exclude.split(',').map(type => (type.trim()));
+    anyType =  anyType.filter(type => !excludedTypesArr.includes(type))
+    
+    return anyType
+}
+
+module.exports = { formatArrayToDelimitedList, formatArray, generateAnyType };

--- a/lib/generateAllTypes.js
+++ b/lib/generateAllTypes.js
@@ -1,0 +1,23 @@
+const { UserInputError } = require('./errors');
+
+/**
+ * Helper for generating all available JSON schema types.
+ *
+ * @param {String} [exclude=''] Types to be excluded separated by comma
+ * @return {Array} Array of string.
+ */
+
+const generateAllTypes = ({ exclude = '' }) => {
+	if (typeof exclude !== 'string') {
+		throw new UserInputError(
+			'The type of "exclude" argument must be string.',
+		);
+	}
+	let types = ['string', 'number', 'object', 'array', 'boolean', 'null'];
+	const excludedTypesArr = exclude.split(',').map((type) => type.trim());
+	types = types.filter((type) => !excludedTypesArr.includes(type));
+
+	return types;
+};
+
+module.exports = generateAllTypes;

--- a/lib/generateAllTypes.js
+++ b/lib/generateAllTypes.js
@@ -7,7 +7,7 @@ const { UserInputError } = require('./errors');
  * @return {Array} Array of string.
  */
 
-const generateAllTypes = ({ exclude = '' }) => {
+const generateAllTypes = ({ exclude = '' } = {}) => {
 	if (typeof exclude !== 'string') {
 		throw new UserInputError(
 			'The type of "exclude" argument must be string.',

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,7 @@ const validatePaginationRange = require('./validatePaginationRange');
 const generateInputSchema = require('./generateInputSchema');
 const formatters = require('./formatters');
 // const xmlFormatter = require('./xmlFormatter');
+const generateAllTypes = require('./generateAllTypes');
 const { mustachedDDL, DDL } = require('./ddl');
 const {
 	UserInputError,
@@ -44,7 +45,7 @@ module.exports = {
 			console.warn(`deepMapKeys: ${deprecationWarning}`);
 			return deepMapKeys(collection, iteratee);
 		},
-		removeEmptyObjects: collection => {
+		removeEmptyObjects: (collection) => {
 			console.warn(`removeEmptyObjects: ${deprecationWarning}`);
 			return removeEmptyObjects(collection);
 		},
@@ -73,6 +74,7 @@ module.exports = {
 	validatePaginationRange,
 	generateInputSchema,
 	formatters,
+	generateAllTypes,
 
 	// Commenting for initial release pending functionality to add paths to treatAsArray
 	// xml: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,16 +14,16 @@
 			}
 		},
 		"@babel/core": {
-			"version": "7.12.1",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.1.tgz",
-			"integrity": "sha512-6bGmltqzIJrinwRRdczQsMhruSi9Sqty9Te+/5hudn4Izx/JYRhW1QELpR+CIL0gC/c9A7WroH6FmkDGxmWx3w==",
+			"version": "7.12.3",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.3.tgz",
+			"integrity": "sha512-0qXcZYKZp3/6N2jKYVxZv0aNCsxTSVCiK72DTiTYZAu7sjg73W0/aynWjMbiGd87EQL4WyA8reiJVh92AVla9g==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.10.4",
 				"@babel/generator": "^7.12.1",
 				"@babel/helper-module-transforms": "^7.12.1",
 				"@babel/helpers": "^7.12.1",
-				"@babel/parser": "^7.12.1",
+				"@babel/parser": "^7.12.3",
 				"@babel/template": "^7.10.4",
 				"@babel/traverse": "^7.12.1",
 				"@babel/types": "^7.12.1",
@@ -38,9 +38,9 @@
 			},
 			"dependencies": {
 				"@babel/parser": {
-					"version": "7.12.2",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.2.tgz",
-					"integrity": "sha512-LMN+SqTiZEonUw4hQA0A3zG8DnN0E1F4K107LbDDUnC+0chML1rvWgsHloC9weB4RmZweE0uhFq0eGX7Nr/PBQ==",
+					"version": "7.12.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.3.tgz",
+					"integrity": "sha512-kFsOS0IbsuhO5ojF8Hc8z/8vEIOkylVBrjiZUbLTE3XFe0Qi+uu6HjzQixkFaqr0ZPAMZcBVxEwmsnsLPZ2Xsw==",
 					"dev": true
 				},
 				"json5": {
@@ -319,18 +319,18 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.11.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-			"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.1.tgz",
+			"integrity": "sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==",
 			"dev": true,
 			"requires": {
 				"regenerator-runtime": "^0.13.4"
 			}
 		},
 		"@babel/runtime-corejs3": {
-			"version": "7.11.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.11.2.tgz",
-			"integrity": "sha512-qh5IR+8VgFz83VBa6OkaET6uN/mJOhHONuy3m1sgF0CV6mXdPSEBdA7e1eUbVvyNtANjMbg22JUv71BaDXLY6A==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.12.1.tgz",
+			"integrity": "sha512-umhPIcMrlBZ2aTWlWjUseW9LjQKxi1dpFlQS8DzsxB//5K+u6GLTC/JliPKHsd5kJVPIU6X/Hy0YvWOYPcMxBw==",
 			"dev": true,
 			"requires": {
 				"core-js-pure": "^3.0.0",
@@ -366,9 +366,9 @@
 			},
 			"dependencies": {
 				"@babel/parser": {
-					"version": "7.12.2",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.2.tgz",
-					"integrity": "sha512-LMN+SqTiZEonUw4hQA0A3zG8DnN0E1F4K107LbDDUnC+0chML1rvWgsHloC9weB4RmZweE0uhFq0eGX7Nr/PBQ==",
+					"version": "7.12.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.3.tgz",
+					"integrity": "sha512-kFsOS0IbsuhO5ojF8Hc8z/8vEIOkylVBrjiZUbLTE3XFe0Qi+uu6HjzQixkFaqr0ZPAMZcBVxEwmsnsLPZ2Xsw==",
 					"dev": true
 				},
 				"globals": {
@@ -407,9 +407,9 @@
 			}
 		},
 		"@eslint/eslintrc": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.1.3.tgz",
-			"integrity": "sha512-4YVwPkANLeNtRjMekzux1ci8hIaH5eGKktGqR0d3LWsKNn5B2X/1Z6Trxy7jQXl9EBGE6Yj02O+t09FMeRllaA==",
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.2.1.tgz",
+			"integrity": "sha512-XRUeBZ5zBWLYgSANMpThFddrZZkEbGHgUdt5UJjZfnlN9BGCiUBrf+nvbRupSjMvqzwnQN0qwCmOxITt1cfywA==",
 			"dev": true,
 			"requires": {
 				"ajv": "^6.12.4",
@@ -521,23 +521,23 @@
 			"dev": true
 		},
 		"@jest/console": {
-			"version": "26.5.2",
-			"resolved": "https://registry.npmjs.org/@jest/console/-/console-26.5.2.tgz",
-			"integrity": "sha512-lJELzKINpF1v74DXHbCRIkQ/+nUV1M+ntj+X1J8LxCgpmJZjfLmhFejiMSbjjD66fayxl5Z06tbs3HMyuik6rw==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-26.6.1.tgz",
+			"integrity": "sha512-cjqcXepwC5M+VeIhwT6Xpi/tT4AiNzlIx8SMJ9IihduHnsSrnWNvTBfKIpmqOOCNOPqtbBx6w2JqfoLOJguo8g==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^26.5.2",
+				"@jest/types": "^26.6.1",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
-				"jest-message-util": "^26.5.2",
-				"jest-util": "^26.5.2",
+				"jest-message-util": "^26.6.1",
+				"jest-util": "^26.6.1",
 				"slash": "^3.0.0"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.5.2",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.1.tgz",
+					"integrity": "sha512-ywHavIKNpAVrStiRY5wiyehvcktpijpItvGiK72RAn5ctqmzvPk8OvKnvHeBqa1XdQr959CTWAJMqxI8BTibyg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -557,9 +557,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.8",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
-					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
+					"version": "15.0.9",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.9.tgz",
+					"integrity": "sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -617,34 +617,34 @@
 			}
 		},
 		"@jest/core": {
-			"version": "26.5.3",
-			"resolved": "https://registry.npmjs.org/@jest/core/-/core-26.5.3.tgz",
-			"integrity": "sha512-CiU0UKFF1V7KzYTVEtFbFmGLdb2g4aTtY0WlyUfLgj/RtoTnJFhh50xKKr7OYkdmBUlGFSa2mD1TU3UZ6OLd4g==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-26.6.1.tgz",
+			"integrity": "sha512-p4F0pgK3rKnoS9olXXXOkbus1Bsu6fd8pcvLMPsUy4CVXZ8WSeiwQ1lK5hwkCIqJ+amZOYPd778sbPha/S8Srw==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^26.5.2",
-				"@jest/reporters": "^26.5.3",
-				"@jest/test-result": "^26.5.2",
-				"@jest/transform": "^26.5.2",
-				"@jest/types": "^26.5.2",
+				"@jest/console": "^26.6.1",
+				"@jest/reporters": "^26.6.1",
+				"@jest/test-result": "^26.6.1",
+				"@jest/transform": "^26.6.1",
+				"@jest/types": "^26.6.1",
 				"@types/node": "*",
 				"ansi-escapes": "^4.2.1",
 				"chalk": "^4.0.0",
 				"exit": "^0.1.2",
 				"graceful-fs": "^4.2.4",
-				"jest-changed-files": "^26.5.2",
-				"jest-config": "^26.5.3",
-				"jest-haste-map": "^26.5.2",
-				"jest-message-util": "^26.5.2",
+				"jest-changed-files": "^26.6.1",
+				"jest-config": "^26.6.1",
+				"jest-haste-map": "^26.6.1",
+				"jest-message-util": "^26.6.1",
 				"jest-regex-util": "^26.0.0",
-				"jest-resolve": "^26.5.2",
-				"jest-resolve-dependencies": "^26.5.3",
-				"jest-runner": "^26.5.3",
-				"jest-runtime": "^26.5.3",
-				"jest-snapshot": "^26.5.3",
-				"jest-util": "^26.5.2",
-				"jest-validate": "^26.5.3",
-				"jest-watcher": "^26.5.2",
+				"jest-resolve": "^26.6.1",
+				"jest-resolve-dependencies": "^26.6.1",
+				"jest-runner": "^26.6.1",
+				"jest-runtime": "^26.6.1",
+				"jest-snapshot": "^26.6.1",
+				"jest-util": "^26.6.1",
+				"jest-validate": "^26.6.1",
+				"jest-watcher": "^26.6.1",
 				"micromatch": "^4.0.2",
 				"p-each-series": "^2.1.0",
 				"rimraf": "^3.0.0",
@@ -653,9 +653,9 @@
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.5.2",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.1.tgz",
+					"integrity": "sha512-ywHavIKNpAVrStiRY5wiyehvcktpijpItvGiK72RAn5ctqmzvPk8OvKnvHeBqa1XdQr959CTWAJMqxI8BTibyg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -675,9 +675,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.8",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
-					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
+					"version": "15.0.9",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.9.tgz",
+					"integrity": "sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -744,21 +744,21 @@
 			}
 		},
 		"@jest/environment": {
-			"version": "26.5.2",
-			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.5.2.tgz",
-			"integrity": "sha512-YjhCD/Zhkz0/1vdlS/QN6QmuUdDkpgBdK4SdiVg4Y19e29g4VQYN5Xg8+YuHjdoWGY7wJHMxc79uDTeTOy9Ngw==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.6.1.tgz",
+			"integrity": "sha512-GNvHwkOFJtNgSwdzH9flUPzF9AYAZhUg124CBoQcwcZCM9s5TLz8Y3fMtiaWt4ffbigoetjGk5PU2Dd8nLrSEw==",
 			"dev": true,
 			"requires": {
-				"@jest/fake-timers": "^26.5.2",
-				"@jest/types": "^26.5.2",
+				"@jest/fake-timers": "^26.6.1",
+				"@jest/types": "^26.6.1",
 				"@types/node": "*",
-				"jest-mock": "^26.5.2"
+				"jest-mock": "^26.6.1"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.5.2",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.1.tgz",
+					"integrity": "sha512-ywHavIKNpAVrStiRY5wiyehvcktpijpItvGiK72RAn5ctqmzvPk8OvKnvHeBqa1XdQr959CTWAJMqxI8BTibyg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -778,9 +778,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.8",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
-					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
+					"version": "15.0.9",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.9.tgz",
+					"integrity": "sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -838,23 +838,23 @@
 			}
 		},
 		"@jest/fake-timers": {
-			"version": "26.5.2",
-			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.5.2.tgz",
-			"integrity": "sha512-09Hn5Oraqt36V1akxQeWMVL0fR9c6PnEhpgLaYvREXZJAh2H2Y+QLCsl0g7uMoJeoWJAuz4tozk1prbR1Fc1sw==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.6.1.tgz",
+			"integrity": "sha512-T/SkMLgOquenw/nIisBRD6XAYpFir0kNuclYLkse5BpzeDUukyBr+K31xgAo9M0hgjU9ORlekAYPSzc0DKfmKg==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^26.5.2",
+				"@jest/types": "^26.6.1",
 				"@sinonjs/fake-timers": "^6.0.1",
 				"@types/node": "*",
-				"jest-message-util": "^26.5.2",
-				"jest-mock": "^26.5.2",
-				"jest-util": "^26.5.2"
+				"jest-message-util": "^26.6.1",
+				"jest-mock": "^26.6.1",
+				"jest-util": "^26.6.1"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.5.2",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.1.tgz",
+					"integrity": "sha512-ywHavIKNpAVrStiRY5wiyehvcktpijpItvGiK72RAn5ctqmzvPk8OvKnvHeBqa1XdQr959CTWAJMqxI8BTibyg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -874,9 +874,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.8",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
-					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
+					"version": "15.0.9",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.9.tgz",
+					"integrity": "sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -934,20 +934,20 @@
 			}
 		},
 		"@jest/globals": {
-			"version": "26.5.3",
-			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.5.3.tgz",
-			"integrity": "sha512-7QztI0JC2CuB+Wx1VdnOUNeIGm8+PIaqngYsZXQCkH2QV0GFqzAYc9BZfU0nuqA6cbYrWh5wkuMzyii3P7deug==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.6.1.tgz",
+			"integrity": "sha512-acxXsSguuLV/CeMYmBseefw6apO7NuXqpE+v5r3yD9ye2PY7h1nS20vY7Obk2w6S7eJO4OIAJeDnoGcLC/McEQ==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^26.5.2",
-				"@jest/types": "^26.5.2",
-				"expect": "^26.5.3"
+				"@jest/environment": "^26.6.1",
+				"@jest/types": "^26.6.1",
+				"expect": "^26.6.1"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.5.2",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.1.tgz",
+					"integrity": "sha512-ywHavIKNpAVrStiRY5wiyehvcktpijpItvGiK72RAn5ctqmzvPk8OvKnvHeBqa1XdQr959CTWAJMqxI8BTibyg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -967,9 +967,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.8",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
-					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
+					"version": "15.0.9",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.9.tgz",
+					"integrity": "sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -1027,16 +1027,16 @@
 			}
 		},
 		"@jest/reporters": {
-			"version": "26.5.3",
-			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.5.3.tgz",
-			"integrity": "sha512-X+vR0CpfMQzYcYmMFKNY9n4jklcb14Kffffp7+H/MqitWnb0440bW2L76NGWKAa+bnXhNoZr+lCVtdtPmfJVOQ==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.6.1.tgz",
+			"integrity": "sha512-J6OlXVFY3q1SXWJhjme5i7qT/BAZSikdOK2t8Ht5OS32BDo6KfG5CzIzzIFnAVd82/WWbc9Hb7SJ/jwSvVH9YA==",
 			"dev": true,
 			"requires": {
 				"@bcoe/v8-coverage": "^0.2.3",
-				"@jest/console": "^26.5.2",
-				"@jest/test-result": "^26.5.2",
-				"@jest/transform": "^26.5.2",
-				"@jest/types": "^26.5.2",
+				"@jest/console": "^26.6.1",
+				"@jest/test-result": "^26.6.1",
+				"@jest/transform": "^26.6.1",
+				"@jest/types": "^26.6.1",
 				"chalk": "^4.0.0",
 				"collect-v8-coverage": "^1.0.0",
 				"exit": "^0.1.2",
@@ -1047,10 +1047,10 @@
 				"istanbul-lib-report": "^3.0.0",
 				"istanbul-lib-source-maps": "^4.0.0",
 				"istanbul-reports": "^3.0.2",
-				"jest-haste-map": "^26.5.2",
-				"jest-resolve": "^26.5.2",
-				"jest-util": "^26.5.2",
-				"jest-worker": "^26.5.0",
+				"jest-haste-map": "^26.6.1",
+				"jest-resolve": "^26.6.1",
+				"jest-util": "^26.6.1",
+				"jest-worker": "^26.6.1",
 				"node-notifier": "^8.0.0",
 				"slash": "^3.0.0",
 				"source-map": "^0.6.0",
@@ -1060,9 +1060,9 @@
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.5.2",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.1.tgz",
+					"integrity": "sha512-ywHavIKNpAVrStiRY5wiyehvcktpijpItvGiK72RAn5ctqmzvPk8OvKnvHeBqa1XdQr959CTWAJMqxI8BTibyg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -1082,9 +1082,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.8",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
-					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
+					"version": "15.0.9",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.9.tgz",
+					"integrity": "sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -1153,21 +1153,21 @@
 			}
 		},
 		"@jest/test-result": {
-			"version": "26.5.2",
-			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.5.2.tgz",
-			"integrity": "sha512-E/Zp6LURJEGSCWpoMGmCFuuEI1OWuI3hmZwmULV0GsgJBh7u0rwqioxhRU95euUuviqBDN8ruX/vP/4bwYolXw==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.6.1.tgz",
+			"integrity": "sha512-wqAgIerIN2gSdT2A8WeA5+AFh9XQBqYGf8etK143yng3qYd0mF0ie2W5PVmgnjw4VDU6ammI9NdXrKgNhreawg==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^26.5.2",
-				"@jest/types": "^26.5.2",
+				"@jest/console": "^26.6.1",
+				"@jest/types": "^26.6.1",
 				"@types/istanbul-lib-coverage": "^2.0.0",
 				"collect-v8-coverage": "^1.0.0"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.5.2",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.1.tgz",
+					"integrity": "sha512-ywHavIKNpAVrStiRY5wiyehvcktpijpItvGiK72RAn5ctqmzvPk8OvKnvHeBqa1XdQr959CTWAJMqxI8BTibyg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -1187,9 +1187,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.8",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
-					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
+					"version": "15.0.9",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.9.tgz",
+					"integrity": "sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -1247,34 +1247,34 @@
 			}
 		},
 		"@jest/test-sequencer": {
-			"version": "26.5.3",
-			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.5.3.tgz",
-			"integrity": "sha512-Wqzb7aQ13L3T47xHdpUqYMOpiqz6Dx2QDDghp5AV/eUDXR7JieY+E1s233TQlNyl+PqtqgjVokmyjzX/HA51BA==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.6.1.tgz",
+			"integrity": "sha512-0csqA/XApZiNeTIPYh6koIDCACSoR6hi29T61tKJMtCZdEC+tF3PoNt7MS0oK/zKC6daBgCbqXxia5ztr/NyCQ==",
 			"dev": true,
 			"requires": {
-				"@jest/test-result": "^26.5.2",
+				"@jest/test-result": "^26.6.1",
 				"graceful-fs": "^4.2.4",
-				"jest-haste-map": "^26.5.2",
-				"jest-runner": "^26.5.3",
-				"jest-runtime": "^26.5.3"
+				"jest-haste-map": "^26.6.1",
+				"jest-runner": "^26.6.1",
+				"jest-runtime": "^26.6.1"
 			}
 		},
 		"@jest/transform": {
-			"version": "26.5.2",
-			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.5.2.tgz",
-			"integrity": "sha512-AUNjvexh+APhhmS8S+KboPz+D3pCxPvEAGduffaAJYxIFxGi/ytZQkrqcKDUU0ERBAo5R7087fyOYr2oms1seg==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.6.1.tgz",
+			"integrity": "sha512-oNFAqVtqRxZRx6vXL3I4bPKUK0BIlEeaalkwxyQGGI8oXDQBtYQBpiMe5F7qPs4QdvvFYB42gPGIMMcxXaBBxQ==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.1.0",
-				"@jest/types": "^26.5.2",
+				"@jest/types": "^26.6.1",
 				"babel-plugin-istanbul": "^6.0.0",
 				"chalk": "^4.0.0",
 				"convert-source-map": "^1.4.0",
 				"fast-json-stable-stringify": "^2.0.0",
 				"graceful-fs": "^4.2.4",
-				"jest-haste-map": "^26.5.2",
+				"jest-haste-map": "^26.6.1",
 				"jest-regex-util": "^26.0.0",
-				"jest-util": "^26.5.2",
+				"jest-util": "^26.6.1",
 				"micromatch": "^4.0.2",
 				"pirates": "^4.0.1",
 				"slash": "^3.0.0",
@@ -1283,9 +1283,9 @@
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.5.2",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.1.tgz",
+					"integrity": "sha512-ywHavIKNpAVrStiRY5wiyehvcktpijpItvGiK72RAn5ctqmzvPk8OvKnvHeBqa1XdQr959CTWAJMqxI8BTibyg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -1305,9 +1305,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.8",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
-					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
+					"version": "15.0.9",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.9.tgz",
+					"integrity": "sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -1461,9 +1461,9 @@
 			}
 		},
 		"@types/graceful-fs": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.3.tgz",
-			"integrity": "sha512-AiHRaEB50LQg0pZmm659vNBb9f4SJ0qrAnteuzhSeAUcJKxoYgEnprg/83kppCnc2zvtCKbdZry1a5pVY3lOTQ==",
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.4.tgz",
+			"integrity": "sha512-mWA/4zFQhfvOA8zWkXobwJvBD7vzcxgrOQ0J5CH1votGqdq9m7+FwtGaqyCZqC3NyyBkc9z4m+iry4LlqcMWJg==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*"
@@ -1507,9 +1507,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "14.11.8",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.8.tgz",
-			"integrity": "sha512-KPcKqKm5UKDkaYPTuXSx8wEP7vE9GnuaXIZKijwRYcePpZFDVuy2a57LarFKiORbHOuTOOwYzxVxcUzsh2P2Pw==",
+			"version": "14.14.6",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.6.tgz",
+			"integrity": "sha512-6QlRuqsQ/Ox/aJEQWBEJG7A9+u7oSYl3mem/K8IzxXG/kAGbV1YPD9Bg9Zw3vyxC/YP+zONKwy8hGkSt1jxFMw==",
 			"dev": true
 		},
 		"@types/normalize-package-data": {
@@ -1519,9 +1519,9 @@
 			"dev": true
 		},
 		"@types/prettier": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.2.tgz",
-			"integrity": "sha512-IiPhNnenzkqdSdQH3ifk9LoX7oQe61ZlDdDO4+MUv6FyWdPGDPr26gCPVs3oguZEMq//nFZZpwUZcVuNJsG+DQ==",
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.5.tgz",
+			"integrity": "sha512-UEyp8LwZ4Dg30kVU2Q3amHHyTn1jEdhCIE59ANed76GaT1Vp76DD3ZWSAxgCrw6wJ0TqeoBpqmfUHiUDPs//HQ==",
 			"dev": true
 		},
 		"@types/stack-utils": {
@@ -1888,9 +1888,9 @@
 			"dev": true
 		},
 		"axe-core": {
-			"version": "3.5.5",
-			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.5.tgz",
-			"integrity": "sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.0.2.tgz",
+			"integrity": "sha512-arU1h31OGFu+LPrOLGZ7nB45v940NMDMEJeNmbutu57P+UFDVnkZg3e+J1I2HJRZ9hT7gO8J91dn/PMrAiKakA==",
 			"dev": true
 		},
 		"axobject-query": {
@@ -1900,13 +1900,13 @@
 			"dev": true
 		},
 		"babel-jest": {
-			"version": "26.5.2",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.5.2.tgz",
-			"integrity": "sha512-U3KvymF3SczA3vOL/cgiUFOznfMET+XDIXiWnoJV45siAp2pLMG8i2+/MGZlAC3f/F6Q40LR4M4qDrWZ9wkK8A==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.6.1.tgz",
+			"integrity": "sha512-duMWEOKrSBYRVTTNpL2SipNIWnZOjP77auOBMPQ3zXAdnDbyZQWU8r/RxNWpUf9N6cgPFecQYelYLytTVXVDtA==",
 			"dev": true,
 			"requires": {
-				"@jest/transform": "^26.5.2",
-				"@jest/types": "^26.5.2",
+				"@jest/transform": "^26.6.1",
+				"@jest/types": "^26.6.1",
 				"@types/babel__core": "^7.1.7",
 				"babel-plugin-istanbul": "^6.0.0",
 				"babel-preset-jest": "^26.5.0",
@@ -1916,9 +1916,9 @@
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.5.2",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.1.tgz",
+					"integrity": "sha512-ywHavIKNpAVrStiRY5wiyehvcktpijpItvGiK72RAn5ctqmzvPk8OvKnvHeBqa1XdQr959CTWAJMqxI8BTibyg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -1938,9 +1938,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.8",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
-					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
+					"version": "15.0.9",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.9.tgz",
+					"integrity": "sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -2252,6 +2252,12 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
 			"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+			"dev": true
+		},
+		"cjs-module-lexer": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-0.4.3.tgz",
+			"integrity": "sha512-5RLK0Qfs0PNDpEyBXIr3bIT1Muw3ojSlvpw6dAmkUcO0+uTrsBn7GuEIgx40u+OzbCBLDta7nvmud85P4EmTsQ==",
 			"dev": true
 		},
 		"class-utils": {
@@ -2616,11 +2622,11 @@
 			"dev": true
 		},
 		"deepdash": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/deepdash/-/deepdash-5.3.0.tgz",
-			"integrity": "sha512-4/nV/Q/pGg6LM5xVDHeuGNVp9ljSifywGme1p6kB4RY64V+UiZ0RLXOsKzMlOIcrQKPeXQKVuimdN5aHyHOEUA==",
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/deepdash/-/deepdash-5.3.2.tgz",
+			"integrity": "sha512-Qm2IUr6GsPJQJNATj2g93VvC6n5raH+WtBQw78LNkgxYmlFLV94/l1NcqlsmuPhJV5+GndIsWcPJ6E69kiFIAg==",
 			"requires": {
-				"lodash": "^4.17.19",
+				"lodash": "^4.17.20",
 				"lodash-es": "^4.17.15"
 			}
 		},
@@ -2779,9 +2785,9 @@
 			}
 		},
 		"emittery": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/emittery/-/emittery-0.7.1.tgz",
-			"integrity": "sha512-d34LN4L6h18Bzz9xpoku2nPwKxCPlPMr3EEKTkoEBi+1/+b0lcRkRJ1UVyyZaKNeqGR3swcGl6s390DNO4YVgQ==",
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/emittery/-/emittery-0.7.2.tgz",
+			"integrity": "sha512-A8OG5SR/ij3SsJdWDJdkkSYUjQdCUx6APQXem0SaEePBSRg4eymGYwBkKo1Y6DU+af/Jn2dBQqDBvjnr9Vi8nQ==",
 			"dev": true
 		},
 		"emoji-regex": {
@@ -2915,13 +2921,13 @@
 			}
 		},
 		"eslint": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.11.0.tgz",
-			"integrity": "sha512-G9+qtYVCHaDi1ZuWzBsOWo2wSwd70TXnU6UHA3cTYHp7gCTXZcpggWFoUVAMRarg68qtPoNfFbzPh+VdOgmwmw==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.12.1.tgz",
+			"integrity": "sha512-HlMTEdr/LicJfN08LB3nM1rRYliDXOmfoO4vj39xN6BLpFzF00hbwBoqHk8UcJ2M/3nlARZWy/mslvGEuZFvsg==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@eslint/eslintrc": "^0.1.3",
+				"@eslint/eslintrc": "^0.2.1",
 				"ajv": "^6.10.0",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
@@ -3022,9 +3028,9 @@
 			}
 		},
 		"eslint-config-prettier": {
-			"version": "6.12.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.12.0.tgz",
-			"integrity": "sha512-9jWPlFlgNwRUYVoujvWTQ1aMO8o6648r+K7qU7K5Jmkbyqav1fuEZC0COYpGBxyiAJb65Ra9hrmFx19xRGwXWw==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz",
+			"integrity": "sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==",
 			"dev": true,
 			"requires": {
 				"get-stdin": "^6.0.0"
@@ -3142,28 +3148,28 @@
 			}
 		},
 		"eslint-plugin-jsx-a11y": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.3.1.tgz",
-			"integrity": "sha512-i1S+P+c3HOlBJzMFORRbC58tHa65Kbo8b52/TwCwSKLohwvpfT5rm2GjGWzOHTEuq4xxf2aRlHHTtmExDQOP+g==",
+			"version": "6.4.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.4.1.tgz",
+			"integrity": "sha512-0rGPJBbwHoGNPU73/QCLP/vveMlM1b1Z9PponxO87jfr6tuH5ligXbDT6nHSSzBC8ovX2Z+BQu7Bk5D/Xgq9zg==",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "^7.10.2",
+				"@babel/runtime": "^7.11.2",
 				"aria-query": "^4.2.2",
 				"array-includes": "^3.1.1",
 				"ast-types-flow": "^0.0.7",
-				"axe-core": "^3.5.4",
-				"axobject-query": "^2.1.2",
+				"axe-core": "^4.0.2",
+				"axobject-query": "^2.2.0",
 				"damerau-levenshtein": "^1.0.6",
 				"emoji-regex": "^9.0.0",
 				"has": "^1.0.3",
-				"jsx-ast-utils": "^2.4.1",
+				"jsx-ast-utils": "^3.1.0",
 				"language-tags": "^1.0.5"
 			},
 			"dependencies": {
 				"emoji-regex": {
-					"version": "9.0.0",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.0.0.tgz",
-					"integrity": "sha512-6p1NII1Vm62wni/VR/cUMauVQoxmLVb9csqQlvLz+hO2gk8U2UYDfXHQSUYIBKmZwAKz867IDqG7B+u0mj+M6w==",
+					"version": "9.2.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.0.tgz",
+					"integrity": "sha512-DNc3KFPK18bPdElMJnf/Pkv5TXhxFU3YFDEuGLDRtPmV4rkmCjBkCSEp22u6rBHdSN9Vlp/GK7k98prmE1Jgug==",
 					"dev": true
 				}
 			}
@@ -3416,23 +3422,23 @@
 			}
 		},
 		"expect": {
-			"version": "26.5.3",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-26.5.3.tgz",
-			"integrity": "sha512-kkpOhGRWGOr+TEFUnYAjfGvv35bfP+OlPtqPIJpOCR9DVtv8QV+p8zG0Edqafh80fsjeE+7RBcVUq1xApnYglw==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-26.6.1.tgz",
+			"integrity": "sha512-BRfxIBHagghMmr1D2MRY0Qv5d3Nc8HCqgbDwNXw/9izmM5eBb42a2YjLKSbsqle76ozGkAEPELQX4IdNHAKRNA==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^26.5.2",
+				"@jest/types": "^26.6.1",
 				"ansi-styles": "^4.0.0",
 				"jest-get-type": "^26.3.0",
-				"jest-matcher-utils": "^26.5.2",
-				"jest-message-util": "^26.5.2",
+				"jest-matcher-utils": "^26.6.1",
+				"jest-message-util": "^26.6.1",
 				"jest-regex-util": "^26.0.0"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.5.2",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.1.tgz",
+					"integrity": "sha512-ywHavIKNpAVrStiRY5wiyehvcktpijpItvGiK72RAn5ctqmzvPk8OvKnvHeBqa1XdQr959CTWAJMqxI8BTibyg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -3452,9 +3458,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.8",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
-					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
+					"version": "15.0.9",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.9.tgz",
+					"integrity": "sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -3507,15 +3513,15 @@
 					"dev": true
 				},
 				"jest-diff": {
-					"version": "26.5.2",
-					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.5.2.tgz",
-					"integrity": "sha512-HCSWDUGwsov5oTlGzrRM+UPJI/Dpqi9jzeV0fdRNi3Ch5bnoXhnyJMmVg2juv9081zLIy3HGPI5mcuGgXM2xRA==",
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.1.tgz",
+					"integrity": "sha512-BBNy/zin2m4kG5In126O8chOBxLLS/XMTuuM2+YhgyHk87ewPzKTuTJcqj3lOWOi03NNgrl+DkMeV/exdvG9gg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^4.0.0",
 						"diff-sequences": "^26.5.0",
 						"jest-get-type": "^26.3.0",
-						"pretty-format": "^26.5.2"
+						"pretty-format": "^26.6.1"
 					}
 				},
 				"jest-get-type": {
@@ -3525,33 +3531,33 @@
 					"dev": true
 				},
 				"jest-matcher-utils": {
-					"version": "26.5.2",
-					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.5.2.tgz",
-					"integrity": "sha512-W9GO9KBIC4gIArsNqDUKsLnhivaqf8MSs6ujO/JDcPIQrmY+aasewweXVET8KdrJ6ADQaUne5UzysvF/RR7JYA==",
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.6.1.tgz",
+					"integrity": "sha512-9iu3zrsYlUnl8pByhREF9rr5eYoiEb1F7ymNKg6lJr/0qD37LWS5FSW/JcoDl8UdMX2+zAzabDs7sTO+QFKjCg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^4.0.0",
-						"jest-diff": "^26.5.2",
+						"jest-diff": "^26.6.1",
 						"jest-get-type": "^26.3.0",
-						"pretty-format": "^26.5.2"
+						"pretty-format": "^26.6.1"
 					}
 				},
 				"pretty-format": {
-					"version": "26.5.2",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.2.tgz",
-					"integrity": "sha512-VizyV669eqESlkOikKJI8Ryxl/kPpbdLwNdPs2GrbQs18MpySB5S0Yo0N7zkg2xTRiFq4CFw8ct5Vg4a0xP0og==",
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.1.tgz",
+					"integrity": "sha512-MeqqsP5PYcRBbGMvwzsyBdmAJ4EFX7pWFyl7x4+dMVg5pE0ZDdBIvEH2ergvIO+Gvwv1wh64YuOY9y5LuyY/GA==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^26.5.2",
+						"@jest/types": "^26.6.1",
 						"ansi-regex": "^5.0.0",
 						"ansi-styles": "^4.0.0",
-						"react-is": "^16.12.0"
+						"react-is": "^17.0.1"
 					}
 				},
 				"react-is": {
-					"version": "16.13.1",
-					"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-					"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+					"version": "17.0.1",
+					"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
+					"integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==",
 					"dev": true
 				},
 				"supports-color": {
@@ -3854,9 +3860,9 @@
 			"dev": true
 		},
 		"gensync": {
-			"version": "1.0.0-beta.1",
-			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
-			"integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
+			"version": "1.0.0-beta.2",
+			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
 			"dev": true
 		},
 		"get-caller-file": {
@@ -4298,6 +4304,15 @@
 				"ci-info": "^2.0.0"
 			}
 		},
+		"is-core-module": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.0.0.tgz",
+			"integrity": "sha512-jq1AH6C8MuteOoBPwkxHafmByhL9j5q4OaPGdbuD+ZtQJVzH+i6E3BJDQcBA09k57i2Hh2yQbEG8yObZ0jdlWw==",
+			"dev": true,
+			"requires": {
+				"has": "^1.0.3"
+			}
+		},
 		"is-data-descriptor": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
@@ -4562,20 +4577,20 @@
 			}
 		},
 		"jest": {
-			"version": "26.5.3",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-26.5.3.tgz",
-			"integrity": "sha512-uJi3FuVSLmkZrWvaDyaVTZGLL8WcfynbRnFXyAHuEtYiSZ+ijDDIMOw1ytmftK+y/+OdAtsG9QrtbF7WIBmOyA==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-26.6.1.tgz",
+			"integrity": "sha512-f+ahfqw3Ffy+9vA7sWFGpTmhtKEMsNAZiWBVXDkrpIO73zIz22iimjirnV78kh/eWlylmvLh/0WxHN6fZraZdA==",
 			"dev": true,
 			"requires": {
-				"@jest/core": "^26.5.3",
+				"@jest/core": "^26.6.1",
 				"import-local": "^3.0.2",
-				"jest-cli": "^26.5.3"
+				"jest-cli": "^26.6.1"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.5.2",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.1.tgz",
+					"integrity": "sha512-ywHavIKNpAVrStiRY5wiyehvcktpijpItvGiK72RAn5ctqmzvPk8OvKnvHeBqa1XdQr959CTWAJMqxI8BTibyg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -4595,9 +4610,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.8",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
-					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
+					"version": "15.0.9",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.9.tgz",
+					"integrity": "sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -4644,22 +4659,22 @@
 					"dev": true
 				},
 				"jest-cli": {
-					"version": "26.5.3",
-					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.5.3.tgz",
-					"integrity": "sha512-HkbSvtugpSXBf2660v9FrNVUgxvPkssN8CRGj9gPM8PLhnaa6zziFiCEKQAkQS4uRzseww45o0TR+l6KeRYV9A==",
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.6.1.tgz",
+					"integrity": "sha512-aPLoEjlwFrCWhiPpW5NUxQA1X1kWsAnQcQ0SO/fHsCvczL3W75iVAcH9kP6NN+BNqZcHNEvkhxT5cDmBfEAh+w==",
 					"dev": true,
 					"requires": {
-						"@jest/core": "^26.5.3",
-						"@jest/test-result": "^26.5.2",
-						"@jest/types": "^26.5.2",
+						"@jest/core": "^26.6.1",
+						"@jest/test-result": "^26.6.1",
+						"@jest/types": "^26.6.1",
 						"chalk": "^4.0.0",
 						"exit": "^0.1.2",
 						"graceful-fs": "^4.2.4",
 						"import-local": "^3.0.2",
 						"is-ci": "^2.0.0",
-						"jest-config": "^26.5.3",
-						"jest-util": "^26.5.2",
-						"jest-validate": "^26.5.3",
+						"jest-config": "^26.6.1",
+						"jest-util": "^26.6.1",
+						"jest-validate": "^26.6.1",
 						"prompts": "^2.0.1",
 						"yargs": "^15.4.1"
 					}
@@ -4676,20 +4691,20 @@
 			}
 		},
 		"jest-changed-files": {
-			"version": "26.5.2",
-			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.5.2.tgz",
-			"integrity": "sha512-qSmssmiIdvM5BWVtyK/nqVpN3spR5YyvkvPqz1x3BR1bwIxsWmU/MGwLoCrPNLbkG2ASAKfvmJpOduEApBPh2w==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.6.1.tgz",
+			"integrity": "sha512-NhSdZ5F6b/rIN5V46x1l31vrmukD/bJUXgYAY8VtP1SknYdJwjYDRxuLt7Z8QryIdqCjMIn2C0Cd98EZ4umo8Q==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^26.5.2",
+				"@jest/types": "^26.6.1",
 				"execa": "^4.0.0",
 				"throat": "^5.0.0"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.5.2",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.1.tgz",
+					"integrity": "sha512-ywHavIKNpAVrStiRY5wiyehvcktpijpItvGiK72RAn5ctqmzvPk8OvKnvHeBqa1XdQr959CTWAJMqxI8BTibyg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -4709,9 +4724,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.8",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
-					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
+					"version": "15.0.9",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.9.tgz",
+					"integrity": "sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -4752,9 +4767,9 @@
 					"dev": true
 				},
 				"execa": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
-					"integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+					"integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
 					"dev": true,
 					"requires": {
 						"cross-spawn": "^7.0.0",
@@ -4810,35 +4825,35 @@
 			}
 		},
 		"jest-config": {
-			"version": "26.5.3",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.5.3.tgz",
-			"integrity": "sha512-NVhZiIuN0GQM6b6as4CI5FSCyXKxdrx5ACMCcv/7Pf+TeCajJhJc+6dwgdAVPyerUFB9pRBIz3bE7clSrRge/w==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.6.1.tgz",
+			"integrity": "sha512-mtJzIynIwW1d1nMlKCNCQiSgWaqFn8cH/fOSNY97xG7Y9tBCZbCSuW2GTX0RPmceSJGO7l27JgwC18LEg0Vg+g==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.1.0",
-				"@jest/test-sequencer": "^26.5.3",
-				"@jest/types": "^26.5.2",
-				"babel-jest": "^26.5.2",
+				"@jest/test-sequencer": "^26.6.1",
+				"@jest/types": "^26.6.1",
+				"babel-jest": "^26.6.1",
 				"chalk": "^4.0.0",
 				"deepmerge": "^4.2.2",
 				"glob": "^7.1.1",
 				"graceful-fs": "^4.2.4",
-				"jest-environment-jsdom": "^26.5.2",
-				"jest-environment-node": "^26.5.2",
+				"jest-environment-jsdom": "^26.6.1",
+				"jest-environment-node": "^26.6.1",
 				"jest-get-type": "^26.3.0",
-				"jest-jasmine2": "^26.5.3",
+				"jest-jasmine2": "^26.6.1",
 				"jest-regex-util": "^26.0.0",
-				"jest-resolve": "^26.5.2",
-				"jest-util": "^26.5.2",
-				"jest-validate": "^26.5.3",
+				"jest-resolve": "^26.6.1",
+				"jest-util": "^26.6.1",
+				"jest-validate": "^26.6.1",
 				"micromatch": "^4.0.2",
-				"pretty-format": "^26.5.2"
+				"pretty-format": "^26.6.1"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.5.2",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.1.tgz",
+					"integrity": "sha512-ywHavIKNpAVrStiRY5wiyehvcktpijpItvGiK72RAn5ctqmzvPk8OvKnvHeBqa1XdQr959CTWAJMqxI8BTibyg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -4858,9 +4873,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.8",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
-					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
+					"version": "15.0.9",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.9.tgz",
+					"integrity": "sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -4913,21 +4928,21 @@
 					"dev": true
 				},
 				"pretty-format": {
-					"version": "26.5.2",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.2.tgz",
-					"integrity": "sha512-VizyV669eqESlkOikKJI8Ryxl/kPpbdLwNdPs2GrbQs18MpySB5S0Yo0N7zkg2xTRiFq4CFw8ct5Vg4a0xP0og==",
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.1.tgz",
+					"integrity": "sha512-MeqqsP5PYcRBbGMvwzsyBdmAJ4EFX7pWFyl7x4+dMVg5pE0ZDdBIvEH2ergvIO+Gvwv1wh64YuOY9y5LuyY/GA==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^26.5.2",
+						"@jest/types": "^26.6.1",
 						"ansi-regex": "^5.0.0",
 						"ansi-styles": "^4.0.0",
-						"react-is": "^16.12.0"
+						"react-is": "^17.0.1"
 					}
 				},
 				"react-is": {
-					"version": "16.13.1",
-					"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-					"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+					"version": "17.0.1",
+					"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
+					"integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==",
 					"dev": true
 				},
 				"supports-color": {
@@ -4963,22 +4978,22 @@
 			}
 		},
 		"jest-each": {
-			"version": "26.5.2",
-			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.5.2.tgz",
-			"integrity": "sha512-w7D9FNe0m2D3yZ0Drj9CLkyF/mGhmBSULMQTypzAKR746xXnjUrK8GUJdlLTWUF6dd0ks3MtvGP7/xNFr9Aphg==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.6.1.tgz",
+			"integrity": "sha512-gSn8eB3buchuq45SU7pLB7qmCGax1ZSxfaWuEFblCyNMtyokYaKFh9dRhYPujK6xYL57dLIPhLKatjmB5XWzGA==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^26.5.2",
+				"@jest/types": "^26.6.1",
 				"chalk": "^4.0.0",
 				"jest-get-type": "^26.3.0",
-				"jest-util": "^26.5.2",
-				"pretty-format": "^26.5.2"
+				"jest-util": "^26.6.1",
+				"pretty-format": "^26.6.1"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.5.2",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.1.tgz",
+					"integrity": "sha512-ywHavIKNpAVrStiRY5wiyehvcktpijpItvGiK72RAn5ctqmzvPk8OvKnvHeBqa1XdQr959CTWAJMqxI8BTibyg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -4998,9 +5013,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.8",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
-					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
+					"version": "15.0.9",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.9.tgz",
+					"integrity": "sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -5053,21 +5068,21 @@
 					"dev": true
 				},
 				"pretty-format": {
-					"version": "26.5.2",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.2.tgz",
-					"integrity": "sha512-VizyV669eqESlkOikKJI8Ryxl/kPpbdLwNdPs2GrbQs18MpySB5S0Yo0N7zkg2xTRiFq4CFw8ct5Vg4a0xP0og==",
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.1.tgz",
+					"integrity": "sha512-MeqqsP5PYcRBbGMvwzsyBdmAJ4EFX7pWFyl7x4+dMVg5pE0ZDdBIvEH2ergvIO+Gvwv1wh64YuOY9y5LuyY/GA==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^26.5.2",
+						"@jest/types": "^26.6.1",
 						"ansi-regex": "^5.0.0",
 						"ansi-styles": "^4.0.0",
-						"react-is": "^16.12.0"
+						"react-is": "^17.0.1"
 					}
 				},
 				"react-is": {
-					"version": "16.13.1",
-					"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-					"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+					"version": "17.0.1",
+					"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
+					"integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==",
 					"dev": true
 				},
 				"supports-color": {
@@ -5082,24 +5097,24 @@
 			}
 		},
 		"jest-environment-jsdom": {
-			"version": "26.5.2",
-			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.5.2.tgz",
-			"integrity": "sha512-fWZPx0bluJaTQ36+PmRpvUtUlUFlGGBNyGX1SN3dLUHHMcQ4WseNEzcGGKOw4U5towXgxI4qDoI3vwR18H0RTw==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.6.1.tgz",
+			"integrity": "sha512-A17RiXuHYNVlkM+3QNcQ6n5EZyAc6eld8ra9TW26luounGWpku4tj03uqRgHJCI1d4uHr5rJiuCH5JFRtdmrcA==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^26.5.2",
-				"@jest/fake-timers": "^26.5.2",
-				"@jest/types": "^26.5.2",
+				"@jest/environment": "^26.6.1",
+				"@jest/fake-timers": "^26.6.1",
+				"@jest/types": "^26.6.1",
 				"@types/node": "*",
-				"jest-mock": "^26.5.2",
-				"jest-util": "^26.5.2",
+				"jest-mock": "^26.6.1",
+				"jest-util": "^26.6.1",
 				"jsdom": "^16.4.0"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.5.2",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.1.tgz",
+					"integrity": "sha512-ywHavIKNpAVrStiRY5wiyehvcktpijpItvGiK72RAn5ctqmzvPk8OvKnvHeBqa1XdQr959CTWAJMqxI8BTibyg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -5119,9 +5134,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.8",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
-					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
+					"version": "15.0.9",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.9.tgz",
+					"integrity": "sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -5179,23 +5194,23 @@
 			}
 		},
 		"jest-environment-node": {
-			"version": "26.5.2",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.5.2.tgz",
-			"integrity": "sha512-YHjnDsf/GKFCYMGF1V+6HF7jhY1fcLfLNBDjhAOvFGvt6d8vXvNdJGVM7uTZ2VO/TuIyEFhPGaXMX5j3h7fsrA==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.6.1.tgz",
+			"integrity": "sha512-YffaCp6h0j1kbcf1NVZ7umC6CPgD67YS+G1BeornfuSkx5s3xdhuwG0DCxSiHPXyT81FfJzA1L7nXvhq50OWIg==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^26.5.2",
-				"@jest/fake-timers": "^26.5.2",
-				"@jest/types": "^26.5.2",
+				"@jest/environment": "^26.6.1",
+				"@jest/fake-timers": "^26.6.1",
+				"@jest/types": "^26.6.1",
 				"@types/node": "*",
-				"jest-mock": "^26.5.2",
-				"jest-util": "^26.5.2"
+				"jest-mock": "^26.6.1",
+				"jest-util": "^26.6.1"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.5.2",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.1.tgz",
+					"integrity": "sha512-ywHavIKNpAVrStiRY5wiyehvcktpijpItvGiK72RAn5ctqmzvPk8OvKnvHeBqa1XdQr959CTWAJMqxI8BTibyg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -5215,9 +5230,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.8",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
-					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
+					"version": "15.0.9",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.9.tgz",
+					"integrity": "sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -5281,12 +5296,12 @@
 			"dev": true
 		},
 		"jest-haste-map": {
-			"version": "26.5.2",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.5.2.tgz",
-			"integrity": "sha512-lJIAVJN3gtO3k4xy+7i2Xjtwh8CfPcH08WYjZpe9xzveDaqGw9fVNCpkYu6M525wKFVkLmyi7ku+DxCAP1lyMA==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.6.1.tgz",
+			"integrity": "sha512-9kPafkv0nX6ta1PrshnkiyhhoQoFWncrU/uUBt3/AP1r78WSCU5iLceYRTwDvJl67H3RrXqSlSVDDa/AsUB7OQ==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^26.5.2",
+				"@jest/types": "^26.6.1",
 				"@types/graceful-fs": "^4.1.2",
 				"@types/node": "*",
 				"anymatch": "^3.0.3",
@@ -5295,17 +5310,17 @@
 				"graceful-fs": "^4.2.4",
 				"jest-regex-util": "^26.0.0",
 				"jest-serializer": "^26.5.0",
-				"jest-util": "^26.5.2",
-				"jest-worker": "^26.5.0",
+				"jest-util": "^26.6.1",
+				"jest-worker": "^26.6.1",
 				"micromatch": "^4.0.2",
 				"sane": "^4.0.3",
 				"walker": "^1.0.7"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.5.2",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.1.tgz",
+					"integrity": "sha512-ywHavIKNpAVrStiRY5wiyehvcktpijpItvGiK72RAn5ctqmzvPk8OvKnvHeBqa1XdQr959CTWAJMqxI8BTibyg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -5325,9 +5340,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.8",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
-					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
+					"version": "15.0.9",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.9.tgz",
+					"integrity": "sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -5385,35 +5400,35 @@
 			}
 		},
 		"jest-jasmine2": {
-			"version": "26.5.3",
-			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.5.3.tgz",
-			"integrity": "sha512-nFlZOpnGlNc7y/+UkkeHnvbOM+rLz4wB1AimgI9QhtnqSZte0wYjbAm8hf7TCwXlXgDwZxAXo6z0a2Wzn9FoOg==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.6.1.tgz",
+			"integrity": "sha512-2uYdT32o/ZzSxYAPduAgokO8OlAL1YdG/9oxcEY138EDNpIK5XRRJDaGzTZdIBWSxk0aR8XxN44FvfXtHB+Fiw==",
 			"dev": true,
 			"requires": {
 				"@babel/traverse": "^7.1.0",
-				"@jest/environment": "^26.5.2",
+				"@jest/environment": "^26.6.1",
 				"@jest/source-map": "^26.5.0",
-				"@jest/test-result": "^26.5.2",
-				"@jest/types": "^26.5.2",
+				"@jest/test-result": "^26.6.1",
+				"@jest/types": "^26.6.1",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
 				"co": "^4.6.0",
-				"expect": "^26.5.3",
+				"expect": "^26.6.1",
 				"is-generator-fn": "^2.0.0",
-				"jest-each": "^26.5.2",
-				"jest-matcher-utils": "^26.5.2",
-				"jest-message-util": "^26.5.2",
-				"jest-runtime": "^26.5.3",
-				"jest-snapshot": "^26.5.3",
-				"jest-util": "^26.5.2",
-				"pretty-format": "^26.5.2",
+				"jest-each": "^26.6.1",
+				"jest-matcher-utils": "^26.6.1",
+				"jest-message-util": "^26.6.1",
+				"jest-runtime": "^26.6.1",
+				"jest-snapshot": "^26.6.1",
+				"jest-util": "^26.6.1",
+				"pretty-format": "^26.6.1",
 				"throat": "^5.0.0"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.5.2",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.1.tgz",
+					"integrity": "sha512-ywHavIKNpAVrStiRY5wiyehvcktpijpItvGiK72RAn5ctqmzvPk8OvKnvHeBqa1XdQr959CTWAJMqxI8BTibyg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -5433,9 +5448,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.8",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
-					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
+					"version": "15.0.9",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.9.tgz",
+					"integrity": "sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -5488,15 +5503,15 @@
 					"dev": true
 				},
 				"jest-diff": {
-					"version": "26.5.2",
-					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.5.2.tgz",
-					"integrity": "sha512-HCSWDUGwsov5oTlGzrRM+UPJI/Dpqi9jzeV0fdRNi3Ch5bnoXhnyJMmVg2juv9081zLIy3HGPI5mcuGgXM2xRA==",
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.1.tgz",
+					"integrity": "sha512-BBNy/zin2m4kG5In126O8chOBxLLS/XMTuuM2+YhgyHk87ewPzKTuTJcqj3lOWOi03NNgrl+DkMeV/exdvG9gg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^4.0.0",
 						"diff-sequences": "^26.5.0",
 						"jest-get-type": "^26.3.0",
-						"pretty-format": "^26.5.2"
+						"pretty-format": "^26.6.1"
 					}
 				},
 				"jest-get-type": {
@@ -5506,33 +5521,33 @@
 					"dev": true
 				},
 				"jest-matcher-utils": {
-					"version": "26.5.2",
-					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.5.2.tgz",
-					"integrity": "sha512-W9GO9KBIC4gIArsNqDUKsLnhivaqf8MSs6ujO/JDcPIQrmY+aasewweXVET8KdrJ6ADQaUne5UzysvF/RR7JYA==",
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.6.1.tgz",
+					"integrity": "sha512-9iu3zrsYlUnl8pByhREF9rr5eYoiEb1F7ymNKg6lJr/0qD37LWS5FSW/JcoDl8UdMX2+zAzabDs7sTO+QFKjCg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^4.0.0",
-						"jest-diff": "^26.5.2",
+						"jest-diff": "^26.6.1",
 						"jest-get-type": "^26.3.0",
-						"pretty-format": "^26.5.2"
+						"pretty-format": "^26.6.1"
 					}
 				},
 				"pretty-format": {
-					"version": "26.5.2",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.2.tgz",
-					"integrity": "sha512-VizyV669eqESlkOikKJI8Ryxl/kPpbdLwNdPs2GrbQs18MpySB5S0Yo0N7zkg2xTRiFq4CFw8ct5Vg4a0xP0og==",
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.1.tgz",
+					"integrity": "sha512-MeqqsP5PYcRBbGMvwzsyBdmAJ4EFX7pWFyl7x4+dMVg5pE0ZDdBIvEH2ergvIO+Gvwv1wh64YuOY9y5LuyY/GA==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^26.5.2",
+						"@jest/types": "^26.6.1",
 						"ansi-regex": "^5.0.0",
 						"ansi-styles": "^4.0.0",
-						"react-is": "^16.12.0"
+						"react-is": "^17.0.1"
 					}
 				},
 				"react-is": {
-					"version": "16.13.1",
-					"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-					"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+					"version": "17.0.1",
+					"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
+					"integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==",
 					"dev": true
 				},
 				"supports-color": {
@@ -5558,19 +5573,19 @@
 			}
 		},
 		"jest-leak-detector": {
-			"version": "26.5.2",
-			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.5.2.tgz",
-			"integrity": "sha512-h7ia3dLzBFItmYERaLPEtEKxy3YlcbcRSjj0XRNJgBEyODuu+3DM2o62kvIFvs3PsaYoIIv+e+nLRI61Dj1CNw==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.6.1.tgz",
+			"integrity": "sha512-j9ZOtJSJKlHjrs4aIxWjiQUjyrffPdiAQn2Iw0916w7qZE5Lk0T2KhIH6E9vfhzP6sw0Q0jtnLLb4vQ71o1HlA==",
 			"dev": true,
 			"requires": {
 				"jest-get-type": "^26.3.0",
-				"pretty-format": "^26.5.2"
+				"pretty-format": "^26.6.1"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.5.2",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.1.tgz",
+					"integrity": "sha512-ywHavIKNpAVrStiRY5wiyehvcktpijpItvGiK72RAn5ctqmzvPk8OvKnvHeBqa1XdQr959CTWAJMqxI8BTibyg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -5590,9 +5605,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.8",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
-					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
+					"version": "15.0.9",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.9.tgz",
+					"integrity": "sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -5645,21 +5660,21 @@
 					"dev": true
 				},
 				"pretty-format": {
-					"version": "26.5.2",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.2.tgz",
-					"integrity": "sha512-VizyV669eqESlkOikKJI8Ryxl/kPpbdLwNdPs2GrbQs18MpySB5S0Yo0N7zkg2xTRiFq4CFw8ct5Vg4a0xP0og==",
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.1.tgz",
+					"integrity": "sha512-MeqqsP5PYcRBbGMvwzsyBdmAJ4EFX7pWFyl7x4+dMVg5pE0ZDdBIvEH2ergvIO+Gvwv1wh64YuOY9y5LuyY/GA==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^26.5.2",
+						"@jest/types": "^26.6.1",
 						"ansi-regex": "^5.0.0",
 						"ansi-styles": "^4.0.0",
-						"react-is": "^16.12.0"
+						"react-is": "^17.0.1"
 					}
 				},
 				"react-is": {
-					"version": "16.13.1",
-					"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-					"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+					"version": "17.0.1",
+					"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
+					"integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==",
 					"dev": true
 				},
 				"supports-color": {
@@ -5686,13 +5701,13 @@
 			}
 		},
 		"jest-message-util": {
-			"version": "26.5.2",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.5.2.tgz",
-			"integrity": "sha512-Ocp9UYZ5Jl15C5PNsoDiGEk14A4NG0zZKknpWdZGoMzJuGAkVt10e97tnEVMYpk7LnQHZOfuK2j/izLBMcuCZw==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.6.1.tgz",
+			"integrity": "sha512-cqM4HnqncIebBNdTKrBoWR/4ufHTll0pK/FWwX0YasK+TlBQEMqw3IEdynuuOTjDPFO3ONlFn37280X48beByw==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@jest/types": "^26.5.2",
+				"@jest/types": "^26.6.1",
 				"@types/stack-utils": "^2.0.0",
 				"chalk": "^4.0.0",
 				"graceful-fs": "^4.2.4",
@@ -5702,9 +5717,9 @@
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.5.2",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.1.tgz",
+					"integrity": "sha512-ywHavIKNpAVrStiRY5wiyehvcktpijpItvGiK72RAn5ctqmzvPk8OvKnvHeBqa1XdQr959CTWAJMqxI8BTibyg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -5724,9 +5739,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.8",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
-					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
+					"version": "15.0.9",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.9.tgz",
+					"integrity": "sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -5784,19 +5799,19 @@
 			}
 		},
 		"jest-mock": {
-			"version": "26.5.2",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.5.2.tgz",
-			"integrity": "sha512-9SiU4b5PtO51v0MtJwVRqeGEroH66Bnwtq4ARdNP7jNXbpT7+ByeWNAk4NeT/uHfNSVDXEXgQo1XRuwEqS6Rdw==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.6.1.tgz",
+			"integrity": "sha512-my0lPTBu1awY8iVG62sB2sx9qf8zxNDVX+5aFgoB8Vbqjb6LqIOsfyFA8P1z6H2IsqMbvOX9oCJnK67Y3yUIMA==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^26.5.2",
+				"@jest/types": "^26.6.1",
 				"@types/node": "*"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.5.2",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.1.tgz",
+					"integrity": "sha512-ywHavIKNpAVrStiRY5wiyehvcktpijpItvGiK72RAn5ctqmzvPk8OvKnvHeBqa1XdQr959CTWAJMqxI8BTibyg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -5816,9 +5831,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.8",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
-					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
+					"version": "15.0.9",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.9.tgz",
+					"integrity": "sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -5888,25 +5903,25 @@
 			"dev": true
 		},
 		"jest-resolve": {
-			"version": "26.5.2",
-			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.5.2.tgz",
-			"integrity": "sha512-XsPxojXGRA0CoDD7Vis59ucz2p3cQFU5C+19tz3tLEAlhYKkK77IL0cjYjikY9wXnOaBeEdm1rOgSJjbZWpcZg==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.6.1.tgz",
+			"integrity": "sha512-hiHfQH6rrcpAmw9xCQ0vD66SDuU+7ZulOuKwc4jpbmFFsz0bQG/Ib92K+9/489u5rVw0btr/ZhiHqBpmkbCvuQ==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^26.5.2",
+				"@jest/types": "^26.6.1",
 				"chalk": "^4.0.0",
 				"graceful-fs": "^4.2.4",
 				"jest-pnp-resolver": "^1.2.2",
-				"jest-util": "^26.5.2",
+				"jest-util": "^26.6.1",
 				"read-pkg-up": "^7.0.1",
-				"resolve": "^1.17.0",
+				"resolve": "^1.18.1",
 				"slash": "^3.0.0"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.5.2",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.1.tgz",
+					"integrity": "sha512-ywHavIKNpAVrStiRY5wiyehvcktpijpItvGiK72RAn5ctqmzvPk8OvKnvHeBqa1XdQr959CTWAJMqxI8BTibyg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -5926,9 +5941,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.8",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
-					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
+					"version": "15.0.9",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.9.tgz",
+					"integrity": "sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -6066,6 +6081,16 @@
 						"type-fest": "^0.8.1"
 					}
 				},
+				"resolve": {
+					"version": "1.18.1",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.18.1.tgz",
+					"integrity": "sha512-lDfCPaMKfOJXjy0dPayzPdF1phampNWr3qFCjAu+rw/qbQmr5jWH5xN2hwh9QKfw9E5v4hwV7A+jrCmL8yjjqA==",
+					"dev": true,
+					"requires": {
+						"is-core-module": "^2.0.0",
+						"path-parse": "^1.0.6"
+					}
+				},
 				"supports-color": {
 					"version": "7.2.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -6078,20 +6103,20 @@
 			}
 		},
 		"jest-resolve-dependencies": {
-			"version": "26.5.3",
-			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.5.3.tgz",
-			"integrity": "sha512-+KMDeke/BFK+mIQ2IYSyBz010h7zQaVt4Xie6cLqUGChorx66vVeQVv4ErNoMwInnyYHi1Ud73tDS01UbXbfLQ==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.6.1.tgz",
+			"integrity": "sha512-MN6lufbZJ3RBfTnJesZtHu3hUCBqPdHRe2+FhIt0yiqJ3fMgzWRqMRQyN/d/QwOE7KXwAG2ekZutbPhuD7s51A==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^26.5.2",
+				"@jest/types": "^26.6.1",
 				"jest-regex-util": "^26.0.0",
-				"jest-snapshot": "^26.5.3"
+				"jest-snapshot": "^26.6.1"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.5.2",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.1.tgz",
+					"integrity": "sha512-ywHavIKNpAVrStiRY5wiyehvcktpijpItvGiK72RAn5ctqmzvPk8OvKnvHeBqa1XdQr959CTWAJMqxI8BTibyg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -6111,9 +6136,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.8",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
-					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
+					"version": "15.0.9",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.9.tgz",
+					"integrity": "sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -6171,37 +6196,37 @@
 			}
 		},
 		"jest-runner": {
-			"version": "26.5.3",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.5.3.tgz",
-			"integrity": "sha512-qproP0Pq7IIule+263W57k2+8kWCszVJTC9TJWGUz0xJBr+gNiniGXlG8rotd0XxwonD5UiJloYoSO5vbUr5FQ==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.6.1.tgz",
+			"integrity": "sha512-DmpNGdgsbl5s0FGkmsInmqnmqCtliCSnjWA2TFAJS1m1mL5atwfPsf+uoZ8uYQ2X0uDj4NM+nPcDnUpbNTRMBA==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^26.5.2",
-				"@jest/environment": "^26.5.2",
-				"@jest/test-result": "^26.5.2",
-				"@jest/types": "^26.5.2",
+				"@jest/console": "^26.6.1",
+				"@jest/environment": "^26.6.1",
+				"@jest/test-result": "^26.6.1",
+				"@jest/types": "^26.6.1",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
 				"emittery": "^0.7.1",
 				"exit": "^0.1.2",
 				"graceful-fs": "^4.2.4",
-				"jest-config": "^26.5.3",
+				"jest-config": "^26.6.1",
 				"jest-docblock": "^26.0.0",
-				"jest-haste-map": "^26.5.2",
-				"jest-leak-detector": "^26.5.2",
-				"jest-message-util": "^26.5.2",
-				"jest-resolve": "^26.5.2",
-				"jest-runtime": "^26.5.3",
-				"jest-util": "^26.5.2",
-				"jest-worker": "^26.5.0",
+				"jest-haste-map": "^26.6.1",
+				"jest-leak-detector": "^26.6.1",
+				"jest-message-util": "^26.6.1",
+				"jest-resolve": "^26.6.1",
+				"jest-runtime": "^26.6.1",
+				"jest-util": "^26.6.1",
+				"jest-worker": "^26.6.1",
 				"source-map-support": "^0.5.6",
 				"throat": "^5.0.0"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.5.2",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.1.tgz",
+					"integrity": "sha512-ywHavIKNpAVrStiRY5wiyehvcktpijpItvGiK72RAn5ctqmzvPk8OvKnvHeBqa1XdQr959CTWAJMqxI8BTibyg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -6221,9 +6246,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.8",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
-					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
+					"version": "15.0.9",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.9.tgz",
+					"integrity": "sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -6281,43 +6306,44 @@
 			}
 		},
 		"jest-runtime": {
-			"version": "26.5.3",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.5.3.tgz",
-			"integrity": "sha512-IDjalmn2s/Tc4GvUwhPHZ0iaXCdMRq5p6taW9P8RpU+FpG01O3+H8z+p3rDCQ9mbyyyviDgxy/LHPLzrIOKBkQ==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.6.1.tgz",
+			"integrity": "sha512-7uOCNeezXDWgjEyzYbRN2ViY7xNZzusNVGAMmU0UHRUNXuY4j4GBHKGMqPo/cBPZA9bSYp+lwK2DRRBU5Dv6YQ==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^26.5.2",
-				"@jest/environment": "^26.5.2",
-				"@jest/fake-timers": "^26.5.2",
-				"@jest/globals": "^26.5.3",
+				"@jest/console": "^26.6.1",
+				"@jest/environment": "^26.6.1",
+				"@jest/fake-timers": "^26.6.1",
+				"@jest/globals": "^26.6.1",
 				"@jest/source-map": "^26.5.0",
-				"@jest/test-result": "^26.5.2",
-				"@jest/transform": "^26.5.2",
-				"@jest/types": "^26.5.2",
+				"@jest/test-result": "^26.6.1",
+				"@jest/transform": "^26.6.1",
+				"@jest/types": "^26.6.1",
 				"@types/yargs": "^15.0.0",
 				"chalk": "^4.0.0",
+				"cjs-module-lexer": "^0.4.2",
 				"collect-v8-coverage": "^1.0.0",
 				"exit": "^0.1.2",
 				"glob": "^7.1.3",
 				"graceful-fs": "^4.2.4",
-				"jest-config": "^26.5.3",
-				"jest-haste-map": "^26.5.2",
-				"jest-message-util": "^26.5.2",
-				"jest-mock": "^26.5.2",
+				"jest-config": "^26.6.1",
+				"jest-haste-map": "^26.6.1",
+				"jest-message-util": "^26.6.1",
+				"jest-mock": "^26.6.1",
 				"jest-regex-util": "^26.0.0",
-				"jest-resolve": "^26.5.2",
-				"jest-snapshot": "^26.5.3",
-				"jest-util": "^26.5.2",
-				"jest-validate": "^26.5.3",
+				"jest-resolve": "^26.6.1",
+				"jest-snapshot": "^26.6.1",
+				"jest-util": "^26.6.1",
+				"jest-validate": "^26.6.1",
 				"slash": "^3.0.0",
 				"strip-bom": "^4.0.0",
 				"yargs": "^15.4.1"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.5.2",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.1.tgz",
+					"integrity": "sha512-ywHavIKNpAVrStiRY5wiyehvcktpijpItvGiK72RAn5ctqmzvPk8OvKnvHeBqa1XdQr959CTWAJMqxI8BTibyg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -6337,9 +6363,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.8",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
-					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
+					"version": "15.0.9",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.9.tgz",
+					"integrity": "sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -6413,33 +6439,33 @@
 			}
 		},
 		"jest-snapshot": {
-			"version": "26.5.3",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.5.3.tgz",
-			"integrity": "sha512-ZgAk0Wm0JJ75WS4lGaeRfa0zIgpL0KD595+XmtwlIEMe8j4FaYHyZhP1LNOO+8fXq7HJ3hll54+sFV9X4+CGVw==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.6.1.tgz",
+			"integrity": "sha512-JA7bZp7HRTIJYAi85pJ/OZ2eur2dqmwIToA5/6d7Mn90isGEfeF9FvuhDLLEczgKP1ihreBzrJ6Vr7zteP5JNA==",
 			"dev": true,
 			"requires": {
 				"@babel/types": "^7.0.0",
-				"@jest/types": "^26.5.2",
+				"@jest/types": "^26.6.1",
 				"@types/babel__traverse": "^7.0.4",
 				"@types/prettier": "^2.0.0",
 				"chalk": "^4.0.0",
-				"expect": "^26.5.3",
+				"expect": "^26.6.1",
 				"graceful-fs": "^4.2.4",
-				"jest-diff": "^26.5.2",
+				"jest-diff": "^26.6.1",
 				"jest-get-type": "^26.3.0",
-				"jest-haste-map": "^26.5.2",
-				"jest-matcher-utils": "^26.5.2",
-				"jest-message-util": "^26.5.2",
-				"jest-resolve": "^26.5.2",
+				"jest-haste-map": "^26.6.1",
+				"jest-matcher-utils": "^26.6.1",
+				"jest-message-util": "^26.6.1",
+				"jest-resolve": "^26.6.1",
 				"natural-compare": "^1.4.0",
-				"pretty-format": "^26.5.2",
+				"pretty-format": "^26.6.1",
 				"semver": "^7.3.2"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.5.2",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.1.tgz",
+					"integrity": "sha512-ywHavIKNpAVrStiRY5wiyehvcktpijpItvGiK72RAn5ctqmzvPk8OvKnvHeBqa1XdQr959CTWAJMqxI8BTibyg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -6459,9 +6485,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.8",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
-					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
+					"version": "15.0.9",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.9.tgz",
+					"integrity": "sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -6514,15 +6540,15 @@
 					"dev": true
 				},
 				"jest-diff": {
-					"version": "26.5.2",
-					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.5.2.tgz",
-					"integrity": "sha512-HCSWDUGwsov5oTlGzrRM+UPJI/Dpqi9jzeV0fdRNi3Ch5bnoXhnyJMmVg2juv9081zLIy3HGPI5mcuGgXM2xRA==",
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.1.tgz",
+					"integrity": "sha512-BBNy/zin2m4kG5In126O8chOBxLLS/XMTuuM2+YhgyHk87ewPzKTuTJcqj3lOWOi03NNgrl+DkMeV/exdvG9gg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^4.0.0",
 						"diff-sequences": "^26.5.0",
 						"jest-get-type": "^26.3.0",
-						"pretty-format": "^26.5.2"
+						"pretty-format": "^26.6.1"
 					}
 				},
 				"jest-get-type": {
@@ -6532,33 +6558,33 @@
 					"dev": true
 				},
 				"jest-matcher-utils": {
-					"version": "26.5.2",
-					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.5.2.tgz",
-					"integrity": "sha512-W9GO9KBIC4gIArsNqDUKsLnhivaqf8MSs6ujO/JDcPIQrmY+aasewweXVET8KdrJ6ADQaUne5UzysvF/RR7JYA==",
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.6.1.tgz",
+					"integrity": "sha512-9iu3zrsYlUnl8pByhREF9rr5eYoiEb1F7ymNKg6lJr/0qD37LWS5FSW/JcoDl8UdMX2+zAzabDs7sTO+QFKjCg==",
 					"dev": true,
 					"requires": {
 						"chalk": "^4.0.0",
-						"jest-diff": "^26.5.2",
+						"jest-diff": "^26.6.1",
 						"jest-get-type": "^26.3.0",
-						"pretty-format": "^26.5.2"
+						"pretty-format": "^26.6.1"
 					}
 				},
 				"pretty-format": {
-					"version": "26.5.2",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.2.tgz",
-					"integrity": "sha512-VizyV669eqESlkOikKJI8Ryxl/kPpbdLwNdPs2GrbQs18MpySB5S0Yo0N7zkg2xTRiFq4CFw8ct5Vg4a0xP0og==",
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.1.tgz",
+					"integrity": "sha512-MeqqsP5PYcRBbGMvwzsyBdmAJ4EFX7pWFyl7x4+dMVg5pE0ZDdBIvEH2ergvIO+Gvwv1wh64YuOY9y5LuyY/GA==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^26.5.2",
+						"@jest/types": "^26.6.1",
 						"ansi-regex": "^5.0.0",
 						"ansi-styles": "^4.0.0",
-						"react-is": "^16.12.0"
+						"react-is": "^17.0.1"
 					}
 				},
 				"react-is": {
-					"version": "16.13.1",
-					"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-					"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+					"version": "17.0.1",
+					"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
+					"integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==",
 					"dev": true
 				},
 				"supports-color": {
@@ -6573,12 +6599,12 @@
 			}
 		},
 		"jest-util": {
-			"version": "26.5.2",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.2.tgz",
-			"integrity": "sha512-WTL675bK+GSSAYgS8z9FWdCT2nccO1yTIplNLPlP0OD8tUk/H5IrWKMMRudIQQ0qp8bb4k+1Qa8CxGKq9qnYdg==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.1.tgz",
+			"integrity": "sha512-xCLZUqVoqhquyPLuDXmH7ogceGctbW8SMyQVjD9o+1+NPWI7t0vO08udcFLVPLgKWcvc+zotaUv/RuaR6l8HIA==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^26.5.2",
+				"@jest/types": "^26.6.1",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
 				"graceful-fs": "^4.2.4",
@@ -6587,9 +6613,9 @@
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.5.2",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.1.tgz",
+					"integrity": "sha512-ywHavIKNpAVrStiRY5wiyehvcktpijpItvGiK72RAn5ctqmzvPk8OvKnvHeBqa1XdQr959CTWAJMqxI8BTibyg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -6609,9 +6635,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.8",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
-					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
+					"version": "15.0.9",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.9.tgz",
+					"integrity": "sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -6669,23 +6695,23 @@
 			}
 		},
 		"jest-validate": {
-			"version": "26.5.3",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.5.3.tgz",
-			"integrity": "sha512-LX07qKeAtY+lsU0o3IvfDdN5KH9OulEGOMN1sFo6PnEf5/qjS1LZIwNk9blcBeW94pQUI9dLN9FlDYDWI5tyaA==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.6.1.tgz",
+			"integrity": "sha512-BEFpGbylKocnNPZULcnk+TGaz1oFZQH/wcaXlaXABbu0zBwkOGczuWgdLucUouuQqn7VadHZZeTvo8VSFDLMOA==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^26.5.2",
+				"@jest/types": "^26.6.1",
 				"camelcase": "^6.0.0",
 				"chalk": "^4.0.0",
 				"jest-get-type": "^26.3.0",
 				"leven": "^3.1.0",
-				"pretty-format": "^26.5.2"
+				"pretty-format": "^26.6.1"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.5.2",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.1.tgz",
+					"integrity": "sha512-ywHavIKNpAVrStiRY5wiyehvcktpijpItvGiK72RAn5ctqmzvPk8OvKnvHeBqa1XdQr959CTWAJMqxI8BTibyg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -6705,9 +6731,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.8",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
-					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
+					"version": "15.0.9",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.9.tgz",
+					"integrity": "sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -6723,9 +6749,9 @@
 					}
 				},
 				"camelcase": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.1.0.tgz",
-					"integrity": "sha512-WCMml9ivU60+8rEJgELlFp1gxFcEGxwYleE3bziHEDeqsqAWGHdimB7beBFGjLzVNgPGyDsfgXLQEYMpmIFnVQ==",
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+					"integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
 					"dev": true
 				},
 				"chalk": {
@@ -6766,21 +6792,21 @@
 					"dev": true
 				},
 				"pretty-format": {
-					"version": "26.5.2",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.2.tgz",
-					"integrity": "sha512-VizyV669eqESlkOikKJI8Ryxl/kPpbdLwNdPs2GrbQs18MpySB5S0Yo0N7zkg2xTRiFq4CFw8ct5Vg4a0xP0og==",
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.1.tgz",
+					"integrity": "sha512-MeqqsP5PYcRBbGMvwzsyBdmAJ4EFX7pWFyl7x4+dMVg5pE0ZDdBIvEH2ergvIO+Gvwv1wh64YuOY9y5LuyY/GA==",
 					"dev": true,
 					"requires": {
-						"@jest/types": "^26.5.2",
+						"@jest/types": "^26.6.1",
 						"ansi-regex": "^5.0.0",
 						"ansi-styles": "^4.0.0",
-						"react-is": "^16.12.0"
+						"react-is": "^17.0.1"
 					}
 				},
 				"react-is": {
-					"version": "16.13.1",
-					"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-					"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+					"version": "17.0.1",
+					"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
+					"integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==",
 					"dev": true
 				},
 				"supports-color": {
@@ -6795,24 +6821,24 @@
 			}
 		},
 		"jest-watcher": {
-			"version": "26.5.2",
-			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.5.2.tgz",
-			"integrity": "sha512-i3m1NtWzF+FXfJ3ljLBB/WQEp4uaNhX7QcQUWMokcifFTUQBDFyUMEwk0JkJ1kopHbx7Een3KX0Q7+9koGM/Pw==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.6.1.tgz",
+			"integrity": "sha512-0LBIPPncNi9CaLKK15bnxyd2E8OMl4kJg0PTiNOI+MXztXw1zVdtX/x9Pr6pXaQYps+eS/ts43O4+HByZ7yJSw==",
 			"dev": true,
 			"requires": {
-				"@jest/test-result": "^26.5.2",
-				"@jest/types": "^26.5.2",
+				"@jest/test-result": "^26.6.1",
+				"@jest/types": "^26.6.1",
 				"@types/node": "*",
 				"ansi-escapes": "^4.2.1",
 				"chalk": "^4.0.0",
-				"jest-util": "^26.5.2",
+				"jest-util": "^26.6.1",
 				"string-length": "^4.0.1"
 			},
 			"dependencies": {
 				"@jest/types": {
-					"version": "26.5.2",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-					"integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+					"version": "26.6.1",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.1.tgz",
+					"integrity": "sha512-ywHavIKNpAVrStiRY5wiyehvcktpijpItvGiK72RAn5ctqmzvPk8OvKnvHeBqa1XdQr959CTWAJMqxI8BTibyg==",
 					"dev": true,
 					"requires": {
 						"@types/istanbul-lib-coverage": "^2.0.0",
@@ -6832,9 +6858,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "15.0.8",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
-					"integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
+					"version": "15.0.9",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.9.tgz",
+					"integrity": "sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -6892,9 +6918,9 @@
 			}
 		},
 		"jest-worker": {
-			"version": "26.5.0",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.5.0.tgz",
-			"integrity": "sha512-kTw66Dn4ZX7WpjZ7T/SUDgRhapFRKWmisVAF0Rv4Fu8SLFD7eLbqpLvbxVqYhSgaWa7I+bW7pHnbyfNsH6stug==",
+			"version": "26.6.1",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.1.tgz",
+			"integrity": "sha512-R5IE3qSGz+QynJx8y+ICEkdI2OJ3RJjRQVEyCcFAd3yVhQSEtquziPO29Mlzgn07LOVE8u8jhJ1FqcwegiXWOw==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*",
@@ -7130,13 +7156,13 @@
 			}
 		},
 		"jsx-ast-utils": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.4.1.tgz",
-			"integrity": "sha512-z1xSldJ6imESSzOjd3NNkieVJKRlKYSOtMG8SFyCj2FIrvSaSuli/WjpBkEzCBoR9bYYYFgqJw61Xhu7Lcgk+w==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.1.0.tgz",
+			"integrity": "sha512-d4/UOjg+mxAWxCiF0c5UTSwyqbchkbqCvK87aBovhnh8GtysTjWmgC63tY0cJx/HzGgm9qnA147jVBdpOiQ2RA==",
 			"dev": true,
 			"requires": {
 				"array-includes": "^3.1.1",
-				"object.assign": "^4.1.0"
+				"object.assign": "^4.1.1"
 			}
 		},
 		"kind-of": {
@@ -7161,9 +7187,9 @@
 			"dev": true
 		},
 		"language-subtag-registry": {
-			"version": "0.3.20",
-			"resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.20.tgz",
-			"integrity": "sha512-KPMwROklF4tEx283Xw0pNKtfTj1gZ4UByp4EsIFWLgBavJltF4TiYPc39k06zSTsLzxTVXXDSpbwaQXaFB4Qeg==",
+			"version": "0.3.21",
+			"resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.21.tgz",
+			"integrity": "sha512-L0IqwlIXjilBVVYKFT37X9Ih11Um5NEl9cbJIuU/SwP/zEEAbBPOnEeeuxVMf45ydWQRDQN3Nqc96OgbH1K+Pg==",
 			"dev": true
 		},
 		"language-tags": {
@@ -7935,13 +7961,13 @@
 			"dev": true
 		},
 		"prompts": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.2.tgz",
-			"integrity": "sha512-Q06uKs2CkNYVID0VqwfAl9mipo99zkBv/n2JtWY89Yxa3ZabWSrs0e2KTudKVa3peLUvYXMefDqIleLPVUBZMA==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.0.tgz",
+			"integrity": "sha512-awZAKrk3vN6CroQukBL+R9051a4R3zCZBlJm/HBfrSZ8iTpYix3VX1vU4mveiLpiwmOJT4wokTF9m6HUk4KqWQ==",
 			"dev": true,
 			"requires": {
 				"kleur": "^3.0.3",
-				"sisteransi": "^1.0.4"
+				"sisteransi": "^1.0.5"
 			}
 		},
 		"psl": {
@@ -9381,9 +9407,9 @@
 			"optional": true
 		},
 		"v8-compile-cache": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
-			"integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
+			"integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
 			"dev": true
 		},
 		"v8-to-istanbul": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@trayio/connector-utils",
-	"version": "0.3.4",
+	"version": "0.3.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@trayio/connector-utils",
-	"version": "0.3.5",
+	"version": "0.3.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@trayio/connector-utils",
-	"version": "0.3.5",
+	"version": "0.3.6",
 	"description": "Common utility functions used in connectors.",
 	"main": "lib/index.js",
 	"scripts": {
@@ -29,21 +29,21 @@
 	},
 	"homepage": "https://github.com/trayio/connector-utils#readme",
 	"devDependencies": {
-		"eslint": "^7.11.0",
+		"eslint": "^7.12.1",
 		"eslint-config-airbnb-base": "^14.2.0",
-		"eslint-config-prettier": "^6.12.0",
+		"eslint-config-prettier": "^6.15.0",
 		"eslint-plugin-import": "^2.22.1",
 		"eslint-plugin-jest": "^24.1.0",
-		"eslint-plugin-jsx-a11y": "^6.3.1",
+		"eslint-plugin-jsx-a11y": "^6.4.1",
 		"eslint-plugin-prettier": "^3.1.4",
 		"eslint-plugin-promise": "^4.2.1",
-		"jest": "^26.5.3",
+		"jest": "^26.6.1",
 		"jest-json-schema": "^2.1.0",
 		"jsdoc-to-markdown": "^6.0.1",
 		"prettier": "^2.1.2"
 	},
 	"dependencies": {
-		"deepdash": "^5.3.0",
+		"deepdash": "^5.3.2",
 		"deepmerge": "^4.2.2",
 		"lodash": "~4.17.20",
 		"mustache": "^4.0.1"

--- a/tests/methods/generateAllTypes.test.js
+++ b/tests/methods/generateAllTypes.test.js
@@ -1,0 +1,65 @@
+const { generateAllTypes } = require('../../lib/index');
+
+const BAD_INPUT = 'jhdsagfjhsdagf';
+
+const ALL_TYPES = ['string', 'number', 'object', 'array', 'boolean', 'null'];
+
+describe('generateAllTypes', () => {
+	it('should return all available JSON schema types', () => {
+		expect(generateAllTypes({})).toEqual(ALL_TYPES);
+	});
+	it('should remove excluded type string', () => {
+		expect(generateAllTypes({ exclude: 'string' })).toEqual(
+			expect.not.arrayContaining(['string']),
+		);
+	});
+	it('should remove excluded type number', () => {
+		expect(generateAllTypes({ exclude: 'number' })).toEqual(
+			expect.not.arrayContaining(['number']),
+		);
+	});
+	it('should remove excluded type object', () => {
+		expect(generateAllTypes({ exclude: 'object' })).toEqual(
+			expect.not.arrayContaining(['object']),
+		);
+	});
+	it('should remove excluded type array', () => {
+		expect(generateAllTypes({ exclude: 'array' })).toEqual(
+			expect.not.arrayContaining(['array']),
+		);
+	});
+	it('should remove excluded type boolean', () => {
+		expect(generateAllTypes({ exclude: 'boolean' })).toEqual(
+			expect.not.arrayContaining(['boolean']),
+		);
+	});
+	it('should remove excluded type null', () => {
+		expect(generateAllTypes({ exclude: 'null' })).toEqual(
+			expect.not.arrayContaining(['null']),
+		);
+	});
+	it('should remove multiple excluded types', () => {
+		expect(generateAllTypes({ exclude: 'null,string,object' })).toEqual(
+			expect.not.arrayContaining(['null', 'string', 'object']),
+		);
+	});
+	it('should remove multiple excluded types if using space', () => {
+		expect(
+			generateAllTypes({ exclude: 'null   , string,   object   ' }),
+		).toEqual(expect.not.arrayContaining(['null', 'string', 'object']));
+	});
+
+	it('should not affect on bad input', () => {
+		expect(
+			generateAllTypes({
+				exclude: `null   , ${BAD_INPUT},   object   `,
+			}),
+		).toEqual(expect.not.arrayContaining(['null', 'object']));
+	});
+
+	it('should throw error if excluded type is not string', () => {
+		expect(() => generateAllTypes({ exclude: ['string'] })).toThrow(
+			'The type of "exclude" argument must be string.',
+		);
+	});
+});

--- a/tests/methods/generateAllTypes.test.js
+++ b/tests/methods/generateAllTypes.test.js
@@ -6,7 +6,7 @@ const ALL_TYPES = ['string', 'number', 'object', 'array', 'boolean', 'null'];
 
 describe('generateAllTypes', () => {
 	it('should return all available JSON schema types', () => {
-		expect(generateAllTypes({})).toEqual(ALL_TYPES);
+		expect(generateAllTypes()).toEqual(ALL_TYPES);
 	});
 	it('should remove excluded type string', () => {
 		expect(generateAllTypes({ exclude: 'string' })).toEqual(


### PR DESCRIPTION
I've seen some devs asked about the `any` type to generate all available JSON schema types to their schema. The tray schema doesn't support this at the moment and I thought to add a simple helper to our utils. 

The `generateAllTypes` will generate all available JSON schema types 
it returns `['string', 'number', 'object', 'array', 'boolean', 'null']`

Devs can exclude any unwanted type by passing the exclude parameter. 

**Example**:

```js
generateAllTypes({})

// returns ['string','number', 'object','array','boolean','null']

generateAllTypes({exclude: 'null, boolean'})

// returns ["string", "number", "object", "array"]